### PR TITLE
AUDIT: FINDING 8 - NONCES_TO_INVALIDATE_TYPEHASH uses uint64 chainId

### DIFF
--- a/src/NonceManager.sol
+++ b/src/NonceManager.sol
@@ -34,7 +34,7 @@ abstract contract NonceManager is INonceManager, EIP712 {
      * @dev Includes chainId for cross-chain replay protection
      */
     bytes32 public constant NONCES_TO_INVALIDATE_TYPEHASH =
-        keccak256("NoncesToInvalidate(uint256 chainId,bytes32[] salts)");
+        keccak256("NoncesToInvalidate(uint64 chainId,bytes32[] salts)");
 
     /**
      * @notice EIP-712 typehash for invalidation signatures

--- a/test/EIP712.t.sol
+++ b/test/EIP712.t.sol
@@ -84,7 +84,7 @@ contract EIP712Test is Test {
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("Test")), // Name
                 keccak256(bytes("1")), // Version
-                uint256(0), // CROSS_CHAIN_ID constant (0) used in EIP712.sol
+                uint256(1), // CROSS_CHAIN_ID constant (1) used in EIP712.sol
                 address(eip712)
             )
         );
@@ -117,7 +117,7 @@ contract EIP712Test is Test {
         assertEq(fields, hex"0f"); // 01111 - indicates which fields are set
         assertEq(name, "Test");
         assertEq(version, "1");
-        assertEq(chainId, 0); // CROSS_CHAIN_ID
+        assertEq(chainId, 1); // CROSS_CHAIN_ID
         assertEq(verifyingContract, address(eip712));
         assertEq(salt, bytes32(0));
         assertEq(extensions.length, 0);
@@ -175,7 +175,7 @@ contract EIP712Test is Test {
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("Test")), // Name
                 keccak256(bytes("1")), // Version
-                uint256(0), // CROSS_CHAIN_ID constant (0) used in EIP712.sol
+                uint256(1), // CROSS_CHAIN_ID constant (1) used in EIP712.sol
                 address(differentAddress)
             )
         );
@@ -233,7 +233,7 @@ contract EIP712Test is Test {
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("TestDomain")),
                 keccak256(bytes("1")),
-                uint256(0), // CROSS_CHAIN_ID constant (0)
+                uint256(1), // CROSS_CHAIN_ID constant (1)
                 address(impl)
             )
         );
@@ -264,7 +264,7 @@ contract EIP712Test is Test {
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("TestDomain")),
                 keccak256(bytes("1")),
-                uint256(0), // CROSS_CHAIN_ID constant (0)
+                uint256(1), // CROSS_CHAIN_ID constant (1)
                 address(alternativeImpl)
             )
         );
@@ -285,7 +285,7 @@ contract AlternativeEIP712 is EIP712 {
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("TestDomain")),
                 keccak256(bytes("1")),
-                uint256(0), // CROSS_CHAIN_ID
+                uint256(1), // CROSS_CHAIN_ID
                 address(this)
             )
         );

--- a/test/ERC7702TokenApprover.t.sol
+++ b/test/ERC7702TokenApprover.t.sol
@@ -38,7 +38,6 @@ contract MockERC20 {
     }
 }
 
-
 contract ERC7702TokenApproverTest is Test {
     ERC7702TokenApprover public approver;
     Permit3 public permit3;
@@ -69,7 +68,7 @@ contract ERC7702TokenApproverTest is Test {
 
         // Use proper EIP-7702 cheatcodes
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         ERC7702TokenApprover(owner).approve(tokens);
@@ -86,7 +85,7 @@ contract ERC7702TokenApproverTest is Test {
 
         // Use proper EIP-7702 cheatcodes
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         ERC7702TokenApprover(owner).approve(tokens);
@@ -102,7 +101,7 @@ contract ERC7702TokenApproverTest is Test {
 
         // Use proper EIP-7702 cheatcodes
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         vm.expectRevert(abi.encodeWithSignature("NoTokensProvided()"));
@@ -118,7 +117,7 @@ contract ERC7702TokenApproverTest is Test {
 
         // Use proper EIP-7702 cheatcodes
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         vm.expectRevert(); // SafeERC20.forceApprove will revert on failure
@@ -137,7 +136,7 @@ contract ERC7702TokenApproverTest is Test {
 
         // Use proper EIP-7702 cheatcodes
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         vm.expectRevert(); // SafeERC20.forceApprove will revert on failure
@@ -161,7 +160,7 @@ contract ERC7702TokenApproverTest is Test {
         tokens[0] = address(token1);
 
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         ERC7702TokenApprover(owner).approve(tokens);
@@ -208,7 +207,7 @@ contract ERC7702TokenApproverTest is Test {
 
         // Use proper EIP-7702 cheatcodes
         Vm.SignedDelegation memory signedDelegation = vm.signDelegation(address(approver), ownerPrivateKey);
-        
+
         vm.startPrank(owner);
         vm.attachDelegation(signedDelegation);
         ERC7702TokenApprover(owner).approve(tokens);

--- a/test/NonceManager.t.sol
+++ b/test/NonceManager.t.sol
@@ -233,7 +233,7 @@ contract NonceManagerTest is TestBase {
         assertEq(fields, hex"0f"); // 01111 - indicates which fields are set
         assertEq(name, "Permit3");
         assertEq(version, "1");
-        assertEq(chainId, 0); // CROSS_CHAIN_ID
+        assertEq(chainId, 1); // CROSS_CHAIN_ID
         assertEq(verifyingContract, address(permit3));
         assertEq(salt, bytes32(0));
         assertEq(extensions.length, 0);


### PR DESCRIPTION
Fix type mismatch between NONCES_TO_INVALIDATE_TYPEHASH constant and actual usage.
The typehash was defined with uint256 chainId but the struct uses uint64 chainId.
Update the typehash to use uint64 for consistency.