### PR TITLE
AUDIT: FINDING 9 - Fix missing allowance checks in batched transferFrom

### DIFF
--- a/src/PermitBase.sol
+++ b/src/PermitBase.sol
@@ -67,7 +67,7 @@ contract PermitBase is IPermit {
      * @param amount Transfer amount
      * @param token ERC20 token address
      */
-    function transferFrom(address from, address to, uint160 amount, address token) external override {
+    function transferFrom(address from, address to, uint160 amount, address token) public override {
         Allowance memory allowed = allowances[from][token][msg.sender];
 
         require(allowed.expiration != LOCKED_ALLOWANCE, AllowanceLocked());
@@ -92,7 +92,7 @@ contract PermitBase is IPermit {
         AllowanceTransferDetails[] calldata transfers
     ) external override {
         for (uint256 i = 0; i < transfers.length; i++) {
-            _transferFrom(transfers[i].from, transfers[i].to, transfers[i].amount, transfers[i].token);
+            transferFrom(transfers[i].from, transfers[i].to, transfers[i].amount, transfers[i].token);
         }
     }
 

--- a/test/PermitBase.t.sol
+++ b/test/PermitBase.t.sol
@@ -90,9 +90,9 @@ contract PermitBaseTest is TestBase {
         assertEq(token.balanceOf(recipient), AMOUNT);
         assertEq(token.balanceOf(recipient2), AMOUNT);
 
-        // Batch transfer doesn't update allowance automatically
+        // Batch transfer now properly updates allowance
         (uint160 amount,,) = permit3.allowance(owner, address(token), spender);
-        assertEq(amount, AMOUNT * 2);
+        assertEq(amount, 0);
     }
 
     function test_transferFromInsufficientAllowance() public {


### PR DESCRIPTION
The batched transferFrom function was bypassing allowance/lock/expiration checks by directly calling _transferFrom. Fixed by making the single transferFrom public and calling it from the batch function to ensure proper validation. Updated test expectations to reflect correct allowance updates after batch transfers.