### PR TITLE
AUDIT: FINDING 10 - Fix UnhingedCancelPermitProof 

### DIFF
--- a/src/NonceManager.sol
+++ b/src/NonceManager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { INonceManager } from "./interfaces/INonceManager.sol";
 import { EIP712 } from "./lib/EIP712.sol";
+import { UnhingedMerkleTree } from "./lib/UnhingedMerkleTree.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /**
@@ -16,6 +17,7 @@ import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
  */
 abstract contract NonceManager is INonceManager, EIP712 {
     using ECDSA for bytes32;
+    using UnhingedMerkleTree for UnhingedProof;
 
     /// @dev Constant representing an unused nonce
     uint256 private constant NONCE_NOT_USED = 0;
@@ -118,13 +120,22 @@ abstract contract NonceManager is INonceManager, EIP712 {
     function invalidateNonces(
         address owner,
         uint256 deadline,
-        UnhingedCancelPermitProof memory proof,
+        UnhingedCancelPermitProof calldata proof,
         bytes calldata signature
     ) external {
         require(block.timestamp <= deadline, SignatureExpired());
         require(proof.invalidations.chainId == block.chainid, WrongChainId(block.chainid, proof.invalidations.chainId));
 
-        bytes32 signedHash = keccak256(abi.encode(SIGNED_CANCEL_PERMIT3_TYPEHASH, owner, deadline, proof.unhingedRoot));
+        // Verify the proof structure is valid
+        if (!proof.unhingedProof.verifyProofStructure()) {
+            revert InvalidUnhingedProof();
+        }
+
+        // Calculate the root from the invalidations and proof
+        bytes32 invalidationsHash = hashNoncesToInvalidate(proof.invalidations);
+        bytes32 unhingedRoot = proof.unhingedProof.calculateRoot(invalidationsHash);
+
+        bytes32 signedHash = keccak256(abi.encode(SIGNED_CANCEL_PERMIT3_TYPEHASH, owner, deadline, unhingedRoot));
 
         bytes32 digest = _hashTypedDataV4(signedHash);
         require(digest.recover(signature) == owner, InvalidSignature());

--- a/src/Permit3.sol
+++ b/src/Permit3.sol
@@ -22,7 +22,6 @@ import { PermitBase } from "./PermitBase.sol";
  */
 contract Permit3 is IPermit3, PermitBase, NonceManager {
     using ECDSA for bytes32;
-    using UnhingedMerkleTree for bytes32;
     using UnhingedMerkleTree for UnhingedProof;
 
     /**

--- a/src/interfaces/INonceManager.sol
+++ b/src/interfaces/INonceManager.sol
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { IUnhingedMerkleTree } from "./IUnhingedMerkleTree.sol";
+
 /**
  * @title INonceManager
  * @notice Interface for managing non-sequential nonces used in permit operations
  */
-interface INonceManager {
+interface INonceManager is IUnhingedMerkleTree {
     /// @notice Thrown when a signature has expired
     error SignatureExpired();
 
@@ -43,7 +45,7 @@ interface INonceManager {
      */
     struct UnhingedCancelPermitProof {
         NoncesToInvalidate invalidations;
-        bytes32 unhingedRoot;
+        UnhingedProof unhingedProof;
     }
 
     /**

--- a/src/interfaces/IPermit3.sol
+++ b/src/interfaces/IPermit3.sol
@@ -3,13 +3,12 @@ pragma solidity ^0.8.0;
 
 import { INonceManager } from "./INonceManager.sol";
 import { IPermit } from "./IPermit.sol";
-import { IUnhingedMerkleTree } from "./IUnhingedMerkleTree.sol";
 
 /**
  * @title IPermit3
  * @notice Interface for the Permit3 cross-chain token approval and transfer system using UnhingedProofs
  */
-interface IPermit3 is IPermit, INonceManager, IUnhingedMerkleTree {
+interface IPermit3 is IPermit, INonceManager {
     /**
      * @notice Enum representing the type of permit operation
      * @param Transfer Execute immediate transfer

--- a/src/interfaces/IUnhingedMerkleTree.sol
+++ b/src/interfaces/IUnhingedMerkleTree.sol
@@ -10,20 +10,20 @@ pragma solidity ^0.8.0;
 interface IUnhingedMerkleTree {
     /**
      * @notice Optimized proof structure for Unhinged Merkle Tree
-     * @param nodes Array of all proof nodes in sequence: [preHash (if present), subtreeProof nodes...,
-     * followingHashes...]
      * @param counts Packed bytes32 that contains all auxiliary data:
      *        - First 120 bits: Number of nodes in subtreeProof
      *        - Next 120 bits: Number of nodes in followingHashes
      *        - Next 15 bits: Reserved for future use
      *        - Last bit: Flag indicating if preHash is present (1) or not (0)
+     * @param nodes Array of all proof nodes in sequence: [preHash (if present), subtreeProof nodes...,
+     * followingHashes...]
      * @dev When hasPreHash=false (last bit=0), the preHash is completely omitted from the
      *      nodes array rather than included as a zero value. This optimization significantly improves
      *      gas efficiency by reducing calldata size and simplifying verification logic.
      */
     struct UnhingedProof {
-        bytes32[] nodes;
         bytes32 counts;
+        bytes32[] nodes;
     }
 
     /**


### PR DESCRIPTION

Fixed the critical security vulnerability where UnhingedCancelPermitProof used a raw bytes32 unhingedRoot field instead of a proper UnhingedProof structure. This allowed malicious relayers to reuse signatures with arbitrary nonce invalidations.

Changes:
- Updated UnhingedCancelPermitProof to use UnhingedProof structure
- Added proper proof verification in invalidateNonces function using verifyProofStructure() and calculateRoot()
- Updated interface inheritance to include IUnhingedMerkleTree in INonceManager
- Fixed test files to work with new proof structure
- Now follows the same secure pattern as UnhingedPermitProof

This prevents the DoS attack where malicious relayers could invalidate all nonces across all chains by reusing old signatures.