### PR TITLE
AUDIT: FINDING 13 - Fix documentation for decrease mode timestamp 

### DIFF
--- a/docs/concepts/allowance-system.md
+++ b/docs/concepts/allowance-system.md
@@ -73,7 +73,7 @@ Reduces an existing allowance.
 **Behavior:**
 - Reduces allowance for `account` by `amountDelta`
 - If `amountDelta` is `type(uint160).max`, resets allowance to 0
-- Updates timestamp to the operation timestamp
+- No change to timestamp (preserves existing timestamp)
 - No change to expiration
 
 ### 3. Lock Mode (2)
@@ -162,8 +162,8 @@ Even though the confirmations happen at different times, both operations use the
 
 ### Rules
 
-- Allowance updates are only applied if the operation timestamp is >= the stored timestamp
-- This is true even for decreases and locks
+- Allowance updates that change timestamps are only applied if the operation timestamp is > the stored timestamp
+- This applies to increases, locks, and unlocks, but NOT to decreases (which preserve existing timestamps)
 - For allowance increases, the highest expiration time is kept when the timestamps are equal
 
 ## Account Locking


### PR DESCRIPTION
The documentation incorrectly stated that decrease operations update timestamps.
In reality, decrease operations preserve existing timestamps and only modify
the allowance amount.

Changes to docs/concepts/allowance-system.md:
- Fixed decrease mode behavior description to clarify timestamp is preserved
- Updated rules section to specify that timestamp updates only apply to
  increases, locks, and unlocks, but NOT decreases

The implementation was already correct - this was a documentation-only issue.