### PR TITLE
AUDIT: FINDING 15 - Fix unlock operation to only remove lock state 

### DIFF
--- a/docs/concepts/allowance-system.md
+++ b/docs/concepts/allowance-system.md
@@ -111,10 +111,9 @@ Removes the locked state from a token.
 ```
 
 **Behavior:**
-- Removes the locked state
-- Sets allowance to `amountDelta`
-- Updates timestamp to current operation time
-- Sets expiration to max (no expiration)
+- Removes the locked state by setting expiration to 0
+- Does not modify allowance amount or timestamp
+- Subsequent increase operation required to set allowance and expiration
 
 ### 5. Increase Mode (>3)
 

--- a/docs/concepts/allowance-system.md
+++ b/docs/concepts/allowance-system.md
@@ -101,12 +101,12 @@ Locks all allowances for a token, providing emergency security control.
 Removes the locked state from a token.
 
 ```solidity
-// Example: Unlock USDC and set allowance to 1000
+// Example: Unlock USDC (requires subsequent increase operation to set allowance)
 {
     modeOrExpiration: 3,             // Unlock mode
     token: USDC_ADDRESS,              // Token to unlock
-    account: DEX_ADDRESS,             // Spender to restore allowance for
-    amountDelta: 1000000000           // New allowance of 1000 USDC
+    account: address(0),              // Not used for unlocking
+    amountDelta: 0                    // Not used for unlocking
 }
 ```
 

--- a/docs/examples/allowance-management-example.md
+++ b/docs/examples/allowance-management-example.md
@@ -194,14 +194,14 @@ const lockPermit = {
 ### 4. Unlock Allowances
 
 ```javascript
-// Unlock USDC and set allowance to 100 USDC
+// Unlock USDC (requires subsequent increase operation to set allowance)
 const unlockPermit = {
     chainId: 1,
     permits: [{
         modeOrExpiration: 3, // Unlock mode
         token: USDC_ADDRESS,
-        account: DEX_ADDRESS,
-        amountDelta: ethers.utils.parseUnits("100", 6)
+        account: ethers.constants.AddressZero, // Not used for unlocking
+        amountDelta: 0 // Not used for unlocking
     }]
 };
 ```

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -371,7 +371,7 @@ const permitData = {
     modeOrExpiration: 3, // Unlock mode
     token: tokenAddress,
     account: address(0), // Not used for unlocking
-    amountDelta: 0 // New allowance after unlock
+    amountDelta: 0 // Not used for unlocking
 };
 ```
 

--- a/src/Permit3.sol
+++ b/src/Permit3.sol
@@ -336,9 +336,9 @@ contract Permit3 is IPermit3, PermitBase, NonceManager {
                     allowed.timestamp = timestamp;
                 } else if (p.modeOrExpiration == uint48(PermitType.Unlock)) {
                     // Unlock allowance
-                    allowed.amount = p.amountDelta;
-                    allowed.expiration = 0;
-                    allowed.timestamp = timestamp;
+                    if (allowed.expiration == LOCKED_ALLOWANCE) {
+                        allowed.expiration = 0;
+                    }
                 } else {
                     if (p.amountDelta > 0) {
                         // Increase allowance

--- a/test/Permit3Edge.t.sol
+++ b/test/Permit3Edge.t.sol
@@ -818,9 +818,10 @@ contract Permit3EdgeTest is Test {
 
         // Check allowance is now unlocked
         (amount, expiration, ts) = permit3.allowance(owner, address(token), spender);
-        assertEq(amount, 3000); // New amount from unlock
-        assertEq(expiration, 0); // No expiration
-        assertEq(ts, unlockParams.timestamp); // Updated timestamp
+        assertEq(amount, 0); // Amount remains unchanged by unlock operation
+        assertEq(expiration, 0); // No expiration (unlocked)
+        // Note: timestamp should remain from lock operation since unlock only changes expiration
+        assertEq(ts, uint48(block.timestamp)); // Timestamp remains from lock operation
     }
 
     function test_attemptUnlockWithOlderTimestamp() public {
@@ -1342,10 +1343,10 @@ contract Permit3EdgeTest is Test {
 
         permit3.permit(owner, params.salt, params.deadline, params.timestamp, inputs.chainPermits, params.signature);
 
-        // Verify allowance is unlocked and equal to AMOUNT
+        // Verify allowance is unlocked but amount remains unchanged
         (uint160 amount, uint48 expiration,) = permit3.allowance(owner, address(token), spender);
-        assertEq(amount, AMOUNT);
-        assertEq(expiration, 0);
+        assertEq(amount, 0); // Amount remains unchanged by unlock operation
+        assertEq(expiration, 0); // Expiration set to 0 (unlocked)
     }
 
     function test_zeroAmountDeltaForIncreaseOperation() public {


### PR DESCRIPTION
- Unlock operation now only sets expiration to 0 when unlocking
- Does not modify allowance amount or timestamp
- Requires subsequent increase operation to set proper allowance and expiration
- Updates documentation to reflect corrected unlock behavior