### PR TITLE
AUDIT REFACTOR 20: Simplify permit API and update function signatures

### DIFF
--- a/EIP-Permit3.md
+++ b/EIP-Permit3.md
@@ -77,7 +77,7 @@ struct AllowanceOrTransfer {
  * @param permits Array of permit operations for this chain
  */
 struct ChainPermits {
-    uint256 chainId;
+    uint64 chainId;
     AllowanceOrTransfer[] permits;
 }
 
@@ -108,12 +108,12 @@ A key innovation in Permit3 is the addition of witness functionality, which allo
  * @param witnessTypeString EIP-712 type definition for witness data
  * @param signature EIP-712 signature authorizing the permits
  */
-function permitWitnessTransferFrom(
+function permitWitness(
     address owner,
     bytes32 salt,
-    uint256 deadline,
+    uint48 deadline,
     uint48 timestamp,
-    ChainPermits memory chain,
+    AllowanceOrTransfer[] calldata permits,
     bytes32 witness,
     string calldata witnessTypeString,
     bytes calldata signature

--- a/docs/api/interfaces.md
+++ b/docs/api/interfaces.md
@@ -16,7 +16,7 @@ The main interface for Permit3, combining IPermit and INonceManager functionalit
 interface IPermit3 is IPermit, INonceManager {
     // Core structs and definitions
     struct ChainPermits {
-        uint256 chainId;
+        uint64 chainId;
         AllowanceOrTransfer[] permits;
     }
     
@@ -43,16 +43,16 @@ interface IPermit3 is IPermit, INonceManager {
     function permit(
         address owner,
         bytes32 salt,
-        uint256 deadline,
+        uint48 deadline,
         uint48 timestamp,
-        ChainPermits calldata chain,
+        AllowanceOrTransfer[] calldata permits,
         bytes calldata signature
     ) external;
     
     function permit(
         address owner,
         bytes32 salt,
-        uint256 deadline,
+        uint48 deadline,
         uint48 timestamp,
         UnhingedPermitProof calldata unhingedPermitProof,
         bytes calldata signature
@@ -64,21 +64,21 @@ interface IPermit3 is IPermit, INonceManager {
     ) external;
     
     // Witness functions
-    function permitWitnessTransferFrom(
+    function permitWitness(
         address owner,
         bytes32 salt,
-        uint256 deadline,
+        uint48 deadline,
         uint48 timestamp,
-        ChainPermits calldata permits,
+        AllowanceOrTransfer[] calldata permits,
         bytes32 witness,
         string calldata witnessTypeString,
         bytes calldata signature
     ) external;
     
-    function permitWitnessTransferFrom(
+    function permitWitness(
         address owner,
         bytes32 salt,
-        uint256 deadline,
+        uint48 deadline,
         uint48 timestamp,
         UnhingedPermitProof calldata unhingedPermitProof,
         bytes32 witness,
@@ -91,7 +91,7 @@ interface IPermit3 is IPermit, INonceManager {
         external view returns (uint160 amount, uint48 expiration, uint48 timestamp);
         
     // Hash functions
-    function hashChainPermits(ChainPermits memory permits) external pure returns (bytes32);
+    function hashChainPermits(ChainPermits memory chainPermits) external pure returns (bytes32);
     
     // Type hash functions
     function PERMIT_TRANSFER_FROM_TYPEHASH() external pure returns (bytes32);

--- a/docs/concepts/cross-chain-operations.md
+++ b/docs/concepts/cross-chain-operations.md
@@ -415,7 +415,7 @@ const witness = ethers.utils.keccak256(
 const witnessTypeString = "Order order)Order(uint256 orderId)";
 
 // Use witnessPermitTransferFrom instead of permit
-await permit3.permitWitnessTransferFrom(
+await permit3.permitWitness(
     permitData.owner,
     permitData.salt,
     permitData.deadline,

--- a/docs/concepts/witness-functionality.md
+++ b/docs/concepts/witness-functionality.md
@@ -30,7 +30,7 @@ The signature is constructed using a dynamic type string that combines the stand
 ```solidity
 // Standard type hash stub (provided by Permit3)
 string constant PERMIT_WITNESS_TYPEHASH_STUB = 
-    "PermitWitnessTransferFrom(ChainPermits permitted,address spender,bytes32 salt,uint256 deadline,uint48 timestamp,";
+    "PermitWitness(address owner,bytes32 salt,uint48 deadline,uint48 timestamp,bytes32 unhingedRoot,";
 
 // Custom witness type (provided by your application)
 string witnessTypeString = "bytes32 witnessData)";
@@ -164,7 +164,7 @@ const domain = {
 };
 
 const types = {
-    PermitWitnessTransferFrom: [
+    PermitWitness: [
         { name: 'permitted', type: 'ChainPermits' },
         { name: 'spender', type: 'address' },
         { name: 'salt', type: 'bytes32' },
@@ -173,7 +173,7 @@ const types = {
         { name: 'witnessData', type: 'bytes32' }
     ],
     ChainPermits: [
-        { name: 'chainId', type: 'uint256' },
+        { name: 'chainId', type: 'uint64' },
         { name: 'permits', type: 'AllowanceOrTransfer[]' }
     ],
     AllowanceOrTransfer: [
@@ -204,15 +204,15 @@ const signature = await signer._signTypedData(domain, types, value);
 
 ### 5. Call the Permit3 Contract
 
-Finally, call the `permitWitnessTransferFrom` function with the witness data and signature:
+Finally, call the `permitWitness` function with the witness data and signature:
 
 ```solidity
-permit3.permitWitnessTransferFrom(
+permit3.permitWitness(
     owner,
     salt,
     deadline,
     timestamp,
-    chainPermits,
+    permits,
     witness,
     witnessTypeString,
     signature
@@ -267,7 +267,7 @@ contract OrderMatcher {
         bytes32 salt,
         uint256 deadline,
         uint48 timestamp,
-        IPermit3.ChainPermits memory chainPermits,
+        IPermit3.AllowanceOrTransfer[] calldata permits,
         bytes32 witness,
         string calldata witnessTypeString,
         bytes calldata signature
@@ -287,12 +287,12 @@ contract OrderMatcher {
         require(block.timestamp <= order.expiration, "Order expired");
         
         // 2. Process the permit with witness
-        permit3.permitWitnessTransferFrom(
+        permit3.permitWitness(
             owner,
             salt,
             deadline,
             timestamp,
-            chainPermits,
+            permits,
             witness,
             witnessTypeString,
             signature

--- a/docs/examples/integration-example.md
+++ b/docs/examples/integration-example.md
@@ -329,7 +329,7 @@ contract Permit3Integration {
         require(witness == expectedWitness, "Invalid witness data");
         
         // Process the permit with witness
-        permit3.permitWitnessTransferFrom(
+        permit3.permitWitness(
             permitOwner,
             salt,
             deadline,

--- a/docs/examples/security-example.md
+++ b/docs/examples/security-example.md
@@ -473,7 +473,7 @@ contract SecureTradeExecutor {
         );
         
         // 3. Execute permit with witness
-        permit3.permitWitnessTransferFrom(
+        permit3.permitWitness(
             owner,
             salt,
             deadline,

--- a/docs/examples/witness-example.md
+++ b/docs/examples/witness-example.md
@@ -86,9 +86,9 @@ function executeOrder(
     Order memory order,
     address maker,
     bytes32 salt,
-    uint256 deadline,
+    uint48 deadline,
     uint48 timestamp,
-    IPermit3.ChainPermits memory chainPermits,
+    IPermit3.AllowanceOrTransfer[] calldata permits,
     bytes32 witness,
     bytes calldata signature
 ) external {
@@ -118,19 +118,19 @@ function executeOrder(
     require(maker == order.maker, "Invalid maker");
     
     // 6. Verify transfer details
-    require(chainPermits.permits.length == 1, "Invalid permit count");
-    require(chainPermits.permits[0].token == order.tokenIn, "Invalid token");
-    require(chainPermits.permits[0].account == address(this), "Invalid recipient");
-    require(chainPermits.permits[0].amountDelta == order.amountIn, "Invalid amount");
-    require(chainPermits.permits[0].modeOrExpiration == 0, "Invalid mode");
+    require(permits.length == 1, "Invalid permit count");
+    require(permits[0].token == order.tokenIn, "Invalid token");
+    require(permits[0].account == address(this), "Invalid recipient");
+    require(permits[0].amountDelta == order.amountIn, "Invalid amount");
+    require(permits[0].modeOrExpiration == 0, "Invalid mode");
     
     // 7. Execute permit with witness
-    permit3.permitWitnessTransferFrom(
+    permit3.permitWitness(
         maker,
         salt,
         deadline,
         timestamp,
-        chainPermits,
+        permits,
         witness,
         getWitnessTypeString(),
         signature
@@ -238,7 +238,7 @@ async function createAndSignOrder(
     
     // 5. Define types
     const types = {
-        PermitWitnessTransferFrom: [
+        PermitWitness: [
             { name: 'permitted', type: 'ChainPermits' },
             { name: 'spender', type: 'address' },
             { name: 'salt', type: 'bytes32' },
@@ -247,7 +247,7 @@ async function createAndSignOrder(
             { name: 'order', type: 'Order' }
         ],
         ChainPermits: [
-            { name: 'chainId', type: 'uint256' },
+            { name: 'chainId', type: 'uint64' },
             { name: 'permits', type: 'AllowanceOrTransfer[]' }
         ],
         AllowanceOrTransfer: [
@@ -414,9 +414,9 @@ function executeMultiSigOrder(
     bytes memory approverSignature,
     address maker,
     bytes32 salt,
-    uint256 deadline,
+    uint48 deadline,
     uint48 timestamp,
-    IPermit3.ChainPermits memory chainPermits,
+    IPermit3.AllowanceOrTransfer[] calldata permits,
     bytes32 witness,
     bytes calldata makerSignature
 ) external {
@@ -458,19 +458,19 @@ function executeMultiSigOrder(
     require(maker == order.maker, "Invalid maker");
     
     // 7. Verify transfer details
-    require(chainPermits.permits.length == 1, "Invalid permit count");
-    require(chainPermits.permits[0].token == order.tokenIn, "Invalid token");
-    require(chainPermits.permits[0].account == address(this), "Invalid recipient");
-    require(chainPermits.permits[0].amountDelta == order.amountIn, "Invalid amount");
-    require(chainPermits.permits[0].modeOrExpiration == 0, "Invalid mode");
+    require(permits.length == 1, "Invalid permit count");
+    require(permits[0].token == order.tokenIn, "Invalid token");
+    require(permits[0].account == address(this), "Invalid recipient");
+    require(permits[0].amountDelta == order.amountIn, "Invalid amount");
+    require(permits[0].modeOrExpiration == 0, "Invalid mode");
     
     // 8. Execute permit with witness (includes maker signature verification)
-    permit3.permitWitnessTransferFrom(
+    permit3.permitWitness(
         maker,
         salt,
         deadline,
         timestamp,
-        chainPermits,
+        permits,
         witness,
         getMultiSigWitnessTypeString(),
         makerSignature
@@ -637,7 +637,7 @@ async function createAndSignMultiSigOrder(
     
     // 6. Define types
     const types = {
-        PermitWitnessTransferFrom: [
+        PermitWitness: [
             { name: 'permitted', type: 'ChainPermits' },
             { name: 'spender', type: 'address' },
             { name: 'salt', type: 'bytes32' },
@@ -646,7 +646,7 @@ async function createAndSignMultiSigOrder(
             { name: 'data', type: 'MultiSigData' }
         ],
         ChainPermits: [
-            { name: 'chainId', type: 'uint256' },
+            { name: 'chainId', type: 'uint64' },
             { name: 'permits', type: 'AllowanceOrTransfer[]' }
         ],
         AllowanceOrTransfer: [

--- a/docs/guides/erc7702-integration.md
+++ b/docs/guides/erc7702-integration.md
@@ -36,7 +36,7 @@ Users create an ERC-7702 transaction that:
 - **Authorizes delegation** to the `ERC7702TokenApprover` contract
 - **Executes multiple operations** via delegatecall (choose one or both):
   - `approve(address[] tokens)` - Batch approve tokens
-  - `permit(ChainPermits memory chain)` - Execute permit operations
+  - `permit(AllowanceOrTransfer[] memory permits)` - Execute permit operations
 
 ### 3. ✅ Result
 

--- a/docs/guides/quick-start.md
+++ b/docs/guides/quick-start.md
@@ -178,7 +178,7 @@ const witnessTypeString = "OrderData data)OrderData(uint256 orderId,uint256 pric
 // Add witness types
 const types = {
     // ... previous types
-    PermitWitnessTransferFrom: [
+    PermitWitness: [
         { name: 'permitted', type: 'ChainPermits' },
         { name: 'spender', type: 'address' },
         { name: 'salt', type: 'bytes32' },
@@ -230,7 +230,7 @@ function executeWitnessPermit(
     require(witness == expectedWitness, "Invalid witness data");
     
     // Execute permit with witness
-    permit3.permitWitnessTransferFrom(
+    permit3.permitWitness(
         owner,
         salt,
         deadline,

--- a/docs/guides/signature-creation.md
+++ b/docs/guides/signature-creation.md
@@ -267,7 +267,7 @@ const witnessTypeString = "OrderData data)OrderData(uint256 orderId,uint256 pric
 ```javascript
 // Types for witness permit
 const witnessTypes = {
-    PermitWitnessTransferFrom: [
+    PermitWitness: [
         { name: 'permitted', type: 'ChainPermits' },
         { name: 'owner', type: 'address' },
         { name: 'spender', type: 'address' },
@@ -311,7 +311,7 @@ const witnessSignature = await signer._signTypedData(domain, witnessTypes, witne
 
 ```javascript
 // Execute the witness permit
-const tx = await permit3.permitWitnessTransferFrom(
+const tx = await permit3.permitWitness(
     witnessValue.owner,
     witnessValue.salt,
     witnessValue.deadline,

--- a/docs/guides/witness-integration.md
+++ b/docs/guides/witness-integration.md
@@ -108,7 +108,7 @@ const domain = {
 
 // Define EIP-712 types for witness permit
 const types = {
-    PermitWitnessTransferFrom: [
+    PermitWitness: [
         { name: 'permitted', type: 'ChainPermits' },
         { name: 'owner', type: 'address' },
         { name: 'spender', type: 'address' },
@@ -184,7 +184,7 @@ const signature = await signer._signTypedData(domain, types, value);
 
 ```typescript
 // Execute permit with witness
-const permitWithWitnessTx = await permit3.permitWitnessTransferFrom(
+const permitWithWitnessTx = await permit3.permitWitness(
     walletAddress,
     salt,
     deadline,
@@ -254,7 +254,7 @@ contract DexWithWitness {
         require(block.timestamp <= orderData.expiration, "Order expired");
         
         // 3. Execute permit with witness
-        permit3.permitWitnessTransferFrom(
+        permit3.permitWitness(
             owner,
             salt,
             deadline,
@@ -280,7 +280,7 @@ For cross-chain operations, you can combine witness functionality with unhinged 
 
 ```typescript
 // Create the permit with witness for cross-chain operation
-const tx = await permit3.permitWitnessTransferFrom(
+const tx = await permit3.permitWitness(
     owner,
     salt,
     deadline,

--- a/scripts/Deploy.s.sol
+++ b/scripts/Deploy.s.sol
@@ -33,6 +33,12 @@ contract Deploy is Script {
         vm.stopBroadcast();
     }
 
+    /**
+     * @notice Deploy a contract using CREATE2 factory
+     * @param initCode The bytecode of the contract to deploy
+     * @param salt Unique salt for deterministic address generation
+     * @return The address of the deployed contract
+     */
     function deploy(bytes memory initCode, bytes32 salt) public returns (address) {
         bytes4 selector = bytes4(keccak256("deploy(bytes,bytes32)"));
         bytes memory args = abi.encode(initCode, salt);

--- a/scripts/DeployApprover.s.sol
+++ b/scripts/DeployApprover.s.sol
@@ -29,6 +29,12 @@ contract DeployApprover is Script {
         vm.stopBroadcast();
     }
 
+    /**
+     * @notice Deploy a contract using CREATE2 factory
+     * @param initCode The bytecode of the contract to deploy
+     * @param salt Unique salt for deterministic address generation
+     * @return The address of the deployed contract
+     */
     function deploy(bytes memory initCode, bytes32 salt) public returns (address) {
         bytes4 selector = bytes4(keccak256("deploy(bytes,bytes32)"));
         bytes memory args = abi.encode(initCode, salt);

--- a/src/NonceManager.sol
+++ b/src/NonceManager.sol
@@ -78,6 +78,10 @@ abstract contract NonceManager is INonceManager, EIP712 {
     ) external {
         uint256 length = salts.length;
 
+        if (length == 0) {
+            revert EmptyArray();
+        }
+
         for (uint256 i = 0; i < length; i++) {
             usedNonces[msg.sender][salts[i]] = NONCE_USED;
             emit NonceInvalidated(msg.sender, salts[i]);
@@ -88,17 +92,22 @@ abstract contract NonceManager is INonceManager, EIP712 {
      * @notice Invalidate nonces using a signed message
      * @param owner Address that signed the invalidation
      * @param deadline Timestamp after which signature is invalid
-     * @param invalidations Struct containing chain ID and nonces to invalidate
+     * @param salts Array of nonce salts to invalidate
      * @param signature EIP-712 signature authorizing invalidation
      */
     function invalidateNonces(
         address owner,
         uint48 deadline,
-        NoncesToInvalidate memory invalidations,
+        bytes32[] calldata salts,
         bytes calldata signature
     ) external {
         require(block.timestamp <= deadline, SignatureExpired());
-        require(invalidations.chainId == block.chainid, WrongChainId(block.chainid, invalidations.chainId));
+
+        if (salts.length == 0) {
+            revert EmptyArray();
+        }
+
+        NoncesToInvalidate memory invalidations = NoncesToInvalidate({ chainId: uint64(block.chainid), salts: salts });
 
         bytes32 signedHash =
             keccak256(abi.encode(CANCEL_PERMIT3_TYPEHASH, owner, deadline, hashNoncesToInvalidate(invalidations)));
@@ -123,7 +132,10 @@ abstract contract NonceManager is INonceManager, EIP712 {
         bytes calldata signature
     ) external {
         require(block.timestamp <= deadline, SignatureExpired());
-        require(proof.invalidations.chainId == block.chainid, WrongChainId(block.chainid, proof.invalidations.chainId));
+        require(
+            proof.invalidations.chainId == uint64(block.chainid),
+            WrongChainId(uint64(block.chainid), proof.invalidations.chainId)
+        );
 
         // Calculate the root from the invalidations and proof
         // calculateRoot performs validation internally and provides granular error messages

--- a/src/PermitBase.sol
+++ b/src/PermitBase.sol
@@ -75,7 +75,9 @@ contract PermitBase is IPermit {
 
         if (allowed.amount != MAX_ALLOWANCE) {
             require(allowed.amount >= amount, InsufficientAllowance(allowed.amount));
-            allowed.amount -= amount;
+            unchecked {
+                allowed.amount -= amount;
+            }
 
             allowances[from][token][msg.sender] = allowed;
         }
@@ -91,6 +93,10 @@ contract PermitBase is IPermit {
     function transferFrom(
         AllowanceTransferDetails[] calldata transfers
     ) external override {
+        if (transfers.length == 0) {
+            revert EmptyArray();
+        }
+
         for (uint256 i = 0; i < transfers.length; i++) {
             transferFrom(transfers[i].from, transfers[i].to, transfers[i].amount, transfers[i].token);
         }
@@ -104,6 +110,10 @@ contract PermitBase is IPermit {
     function lockdown(
         TokenSpenderPair[] calldata approvals
     ) external override {
+        if (approvals.length == 0) {
+            revert EmptyArray();
+        }
+
         for (uint256 i = 0; i < approvals.length; i++) {
             address token = approvals[i].token;
             address spender = approvals[i].spender;

--- a/src/interfaces/INonceManager.sol
+++ b/src/interfaces/INonceManager.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { IPermit } from "./IPermit.sol";
 import { IUnhingedMerkleTree } from "./IUnhingedMerkleTree.sol";
 
 /**
  * @title INonceManager
  * @notice Interface for managing non-sequential nonces used in permit operations
  */
-interface INonceManager is IUnhingedMerkleTree {
+interface INonceManager is IPermit, IUnhingedMerkleTree {
     /// @notice Thrown when a signature has expired
     error SignatureExpired();
 
@@ -74,13 +75,13 @@ interface INonceManager is IUnhingedMerkleTree {
      * @notice Mark nonces as used with signature authorization
      * @param owner Token owner address
      * @param deadline Signature expiration timestamp
-     * @param invalidations Chain-specific nonce invalidation data
+     * @param salts Array of nonce salts to invalidate
      * @param signature EIP-712 signature authorizing the invalidation
      */
     function invalidateNonces(
         address owner,
         uint48 deadline,
-        NoncesToInvalidate memory invalidations,
+        bytes32[] calldata salts,
         bytes calldata signature
     ) external;
 

--- a/src/interfaces/IPermit.sol
+++ b/src/interfaces/IPermit.sol
@@ -26,6 +26,11 @@ interface IPermit {
     error AllowanceLocked();
 
     /**
+     * @notice Thrown when an empty array is provided where it's not allowed
+     */
+    error EmptyArray();
+
+    /**
      * @dev Represents a token and spender pair for batch operations
      * @param token The address of the token contract
      * @param spender The address approved to spend the token

--- a/src/interfaces/IPermit3.sol
+++ b/src/interfaces/IPermit3.sol
@@ -52,7 +52,7 @@ interface IPermit3 is IPermit, INonceManager {
      * @param permits Array of permit operations for this chain
      */
     struct ChainPermits {
-        uint256 chainId;
+        uint64 chainId;
         AllowanceOrTransfer[] permits;
     }
 
@@ -74,11 +74,11 @@ interface IPermit3 is IPermit, INonceManager {
 
     /**
      * @notice Hashes chain permits data for cross-chain operations
-     * @param permits Chain-specific permit data
+     * @param chainPermits Chain-specific permit data
      * @return bytes32 Combined hash of all permit parameters
      */
     function hashChainPermits(
-        ChainPermits memory permits
+        ChainPermits memory chainPermits
     ) external pure returns (bytes32);
 
     /**
@@ -96,7 +96,7 @@ interface IPermit3 is IPermit, INonceManager {
      * @param salt Unique salt for replay protection
      * @param deadline Signature expiration timestamp
      * @param timestamp Timestamp of the permit
-     * @param chain Chain-specific permit data
+     * @param permits Array of permit operations to execute
      * @param signature EIP-712 signature authorizing the permits
      */
     function permit(
@@ -104,7 +104,7 @@ interface IPermit3 is IPermit, INonceManager {
         bytes32 salt,
         uint48 deadline,
         uint48 timestamp,
-        ChainPermits memory chain,
+        AllowanceOrTransfer[] calldata permits,
         bytes calldata signature
     ) external;
 
@@ -132,17 +132,17 @@ interface IPermit3 is IPermit, INonceManager {
      * @param salt Unique salt for replay protection
      * @param deadline Signature expiration timestamp
      * @param timestamp Timestamp of the permit
-     * @param chain Chain-specific permit data
+     * @param permits Array of permit operations to execute
      * @param witness Additional data to include in signature verification
      * @param witnessTypeString EIP-712 type definition for witness data
      * @param signature EIP-712 signature authorizing the permits
      */
-    function permitWitnessTransferFrom(
+    function permitWitness(
         address owner,
         bytes32 salt,
         uint48 deadline,
         uint48 timestamp,
-        ChainPermits memory chain,
+        AllowanceOrTransfer[] calldata permits,
         bytes32 witness,
         string calldata witnessTypeString,
         bytes calldata signature
@@ -159,7 +159,7 @@ interface IPermit3 is IPermit, INonceManager {
      * @param witnessTypeString EIP-712 type definition for witness data
      * @param signature EIP-712 signature authorizing the batch
      */
-    function permitWitnessTransferFrom(
+    function permitWitness(
         address owner,
         bytes32 salt,
         uint48 deadline,

--- a/test/NonceManager.t.sol
+++ b/test/NonceManager.t.sol
@@ -40,7 +40,7 @@ contract NonceManagerTest is TestBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
         bytes memory signature = abi.encodePacked(r, s, v);
 
-        permit3.invalidateNonces(owner, deadline, invalidations, signature);
+        permit3.invalidateNonces(owner, deadline, salts, signature);
 
         assertTrue(permit3.isNonceUsed(owner, bytes32(uint256(1))));
         assertTrue(permit3.isNonceUsed(owner, bytes32(uint256(2))));
@@ -60,7 +60,7 @@ contract NonceManagerTest is TestBase {
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.expectRevert(INonceManager.SignatureExpired.selector);
-        permit3.invalidateNonces(owner, deadline, invalidations, signature);
+        permit3.invalidateNonces(owner, deadline, salts, signature);
     }
 
     function test_signedNonceInvalidationWrongSigner() public {
@@ -77,7 +77,7 @@ contract NonceManagerTest is TestBase {
         bytes memory signature = abi.encodePacked(r, s, v);
 
         vm.expectRevert(INonceManager.InvalidSignature.selector);
-        permit3.invalidateNonces(owner, deadline, invalidations, signature);
+        permit3.invalidateNonces(owner, deadline, salts, signature);
     }
 
     function test_crossChainNonceInvalidation() public {
@@ -131,8 +131,8 @@ contract NonceManagerTest is TestBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
         bytes memory signature = abi.encodePacked(r, s, v);
 
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, block.chainid, 1));
-        permit3.invalidateNonces(owner, deadline, invalidations, signature);
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 1));
+        permit3.invalidateNonces(owner, deadline, salts, signature);
     }
 
     function test_wrongChainIdCrossChainInvalidation() public {
@@ -163,7 +163,7 @@ contract NonceManagerTest is TestBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
         bytes memory signature = abi.encodePacked(r, s, v);
 
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, block.chainid, 1));
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 1));
         permit3.invalidateNonces(owner, deadline, proof, signature);
     }
 

--- a/test/NonceManager.t.sol
+++ b/test/NonceManager.t.sol
@@ -131,7 +131,8 @@ contract NonceManagerTest is TestBase {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ownerPrivateKey, digest);
         bytes memory signature = abi.encodePacked(r, s, v);
 
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 1));
+        // Should revert with InvalidSignature (signature was created for wrong chain ID)
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.InvalidSignature.selector));
         permit3.invalidateNonces(owner, deadline, salts, signature);
     }
 

--- a/test/Permit3.t.sol
+++ b/test/Permit3.t.sol
@@ -103,8 +103,8 @@ contract Permit3Test is TestBase {
         uint48 timestamp = uint48(block.timestamp);
         bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
 
-        // Should revert with WrongChainId
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 999));
+        // Should revert with InvalidSignature (signature was created for wrong chain ID)
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.InvalidSignature.selector));
         permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
     }
 

--- a/test/Permit3.t.sol
+++ b/test/Permit3.t.sol
@@ -25,7 +25,7 @@ contract Permit3Test is TestBase {
         bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
 
         // Execute permit
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
 
         // Verify transfer happened
         assertEq(token.balanceOf(recipient), AMOUNT);
@@ -44,7 +44,7 @@ contract Permit3Test is TestBase {
 
         // Should revert with SignatureExpired
         vm.expectRevert(INonceManager.SignatureExpired.selector);
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
     }
 
     function test_permitTransferFromInvalidSignature() public {
@@ -60,7 +60,7 @@ contract Permit3Test is TestBase {
 
         // Should revert with InvalidSignature
         vm.expectRevert(INonceManager.InvalidSignature.selector);
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
     }
 
     function test_permitTransferFromReusedNonce() public {
@@ -72,11 +72,11 @@ contract Permit3Test is TestBase {
         bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
 
         // First permit should succeed
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
 
         // Second attempt with same nonce should fail
         vm.expectRevert(INonceManager.NonceAlreadyUsed.selector);
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
     }
 
     function test_permitTransferFromWrongChainId() public {
@@ -104,8 +104,8 @@ contract Permit3Test is TestBase {
         bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
 
         // Should revert with WrongChainId
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, block.chainid, 999));
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 999));
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
     }
 
     function test_permitAllowance() public {
@@ -119,14 +119,14 @@ contract Permit3Test is TestBase {
         });
 
         IPermit3.ChainPermits memory chainPermits =
-            IPermit3.ChainPermits({ chainId: uint256(block.chainid), permits: permits });
+            IPermit3.ChainPermits({ chainId: uint64(block.chainid), permits: permits });
 
         uint48 deadline = uint48(block.timestamp + 1 hours);
         uint48 timestamp = uint48(block.timestamp);
         bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
 
         // Execute permit
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
 
         // Verify allowance is set
         (uint160 amount, uint48 expiration,) = permit3.allowance(owner, address(token), spender);
@@ -158,7 +158,7 @@ contract Permit3Test is TestBase {
         });
 
         IPermit3.ChainPermits memory chainPermits =
-            IPermit3.ChainPermits({ chainId: uint256(block.chainid), permits: permits });
+            IPermit3.ChainPermits({ chainId: uint64(block.chainid), permits: permits });
 
         // Reset balances
         deal(address(token), recipient, 0);
@@ -168,7 +168,7 @@ contract Permit3Test is TestBase {
         bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
 
         // Execute permit
-        permit3.permit(owner, SALT, deadline, timestamp, chainPermits, signature);
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
 
         // Verify allowance is set
         (uint160 amount, uint48 expiration,) = permit3.allowance(owner, address(token), spender);
@@ -292,7 +292,7 @@ contract Permit3Test is TestBase {
         bytes memory signature = new bytes(65);
 
         // Test that wrong chain ID reverts with WrongChainId error
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, block.chainid, 999));
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 999));
         vm.prank(owner);
         permit3.permit(owner, SALT, deadline, timestamp, permitProof, signature);
 

--- a/test/Permit3Witness.t.sol
+++ b/test/Permit3Witness.t.sol
@@ -65,19 +65,19 @@ contract Permit3WitnessTest is Test {
     function test_validateWitnessTypeString() public {
         // This should revert with InvalidWitnessTypeString
         vm.expectRevert(INonceManager.InvalidWitnessTypeString.selector);
-        permit3.permitWitnessTransferFrom(
+        permit3.permitWitness(
             owner,
             SALT,
             uint48(block.timestamp + 1 hours),
             uint48(block.timestamp),
-            _createBasicTransferPermit(),
+            _createBasicTransferPermit().permits,
             WITNESS,
             INVALID_WITNESS_TYPE_STRING,
             new bytes(65)
         );
     }
 
-    function test_permitWitnessTransferFrom() public {
+    function test_permitWitness() public {
         // Create the permit
         IPermit3.ChainPermits memory chainPermits = _createBasicTransferPermit();
 
@@ -90,8 +90,8 @@ contract Permit3WitnessTest is Test {
             _signWitnessPermit(chainPermits, deadline, timestamp, SALT, WITNESS, WITNESS_TYPE_STRING);
 
         // Execute permit
-        permit3.permitWitnessTransferFrom(
-            owner, SALT, deadline, timestamp, chainPermits, WITNESS, WITNESS_TYPE_STRING, signature
+        permit3.permitWitness(
+            owner, SALT, deadline, timestamp, chainPermits.permits, WITNESS, WITNESS_TYPE_STRING, signature
         );
 
         // Verify transfer happened
@@ -101,7 +101,7 @@ contract Permit3WitnessTest is Test {
         assertTrue(permit3.isNonceUsed(owner, SALT));
     }
 
-    function test_permitWitnessTransferFromExpired() public {
+    function test_permitWitnessExpired() public {
         // Create the permit
         IPermit3.ChainPermits memory chainPermits = _createBasicTransferPermit();
 
@@ -112,12 +112,12 @@ contract Permit3WitnessTest is Test {
             _signWitnessPermit(chainPermits, deadline, timestamp, SALT, WITNESS, WITNESS_TYPE_STRING);
 
         vm.expectRevert(INonceManager.SignatureExpired.selector);
-        permit3.permitWitnessTransferFrom(
-            owner, SALT, deadline, timestamp, chainPermits, WITNESS, WITNESS_TYPE_STRING, signature
+        permit3.permitWitness(
+            owner, SALT, deadline, timestamp, chainPermits.permits, WITNESS, WITNESS_TYPE_STRING, signature
         );
     }
 
-    function test_permitWitnessTransferFromWrongChain() public {
+    function test_permitWitnessWrongChain() public {
         // Create the permit with wrong chain ID
         IPermit3.ChainPermits memory chainPermits = _createWrongChainTransferPermit();
 
@@ -126,9 +126,9 @@ contract Permit3WitnessTest is Test {
         bytes memory signature =
             _signWitnessPermit(chainPermits, deadline, timestamp, SALT, WITNESS, WITNESS_TYPE_STRING);
 
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, block.chainid, 1));
-        permit3.permitWitnessTransferFrom(
-            owner, SALT, deadline, timestamp, chainPermits, WITNESS, WITNESS_TYPE_STRING, signature
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 1));
+        permit3.permitWitness(
+            owner, SALT, deadline, timestamp, chainPermits.permits, WITNESS, WITNESS_TYPE_STRING, signature
         );
     }
 
@@ -147,7 +147,7 @@ contract Permit3WitnessTest is Test {
         bytes signature;
     }
 
-    function test_permitWitnessTransferFromInvalidSignature() public {
+    function test_permitWitnessInvalidSignature() public {
         InvalidSignatureVars memory vars;
 
         // Create the permit
@@ -176,12 +176,19 @@ contract Permit3WitnessTest is Test {
         vars.signature = abi.encodePacked(vars.r, vars.s, vars.v);
 
         vm.expectRevert(INonceManager.InvalidSignature.selector);
-        permit3.permitWitnessTransferFrom(
-            owner, SALT, vars.deadline, vars.timestamp, vars.chainPermits, WITNESS, WITNESS_TYPE_STRING, vars.signature
+        permit3.permitWitness(
+            owner,
+            SALT,
+            vars.deadline,
+            vars.timestamp,
+            vars.chainPermits.permits,
+            WITNESS,
+            WITNESS_TYPE_STRING,
+            vars.signature
         );
     }
 
-    function test_permitWitnessTransferFromAllowance() public {
+    function test_permitWitnessAllowance() public {
         // Create allowance permit
         IPermit3.ChainPermits memory chainPermits = _createAllowancePermit();
 
@@ -190,8 +197,8 @@ contract Permit3WitnessTest is Test {
         bytes memory signature =
             _signWitnessPermit(chainPermits, deadline, timestamp, SALT, WITNESS, WITNESS_TYPE_STRING);
 
-        permit3.permitWitnessTransferFrom(
-            owner, SALT, deadline, timestamp, chainPermits, WITNESS, WITNESS_TYPE_STRING, signature
+        permit3.permitWitness(
+            owner, SALT, deadline, timestamp, chainPermits.permits, WITNESS, WITNESS_TYPE_STRING, signature
         );
 
         // Verify allowance was set
@@ -208,7 +215,7 @@ contract Permit3WitnessTest is Test {
         assertEq(allowance, AMOUNT / 2);
     }
 
-    function test_permitWitnessTransferFromDifferentWitnesses() public {
+    function test_permitWitnessDifferentWitnesses() public {
         // First transfer with witness1
         {
             IPermit3.ChainPermits memory chainPermits = _createBasicTransferPermit();
@@ -220,8 +227,8 @@ contract Permit3WitnessTest is Test {
             bytes memory signature =
                 _signWitnessPermit(chainPermits, deadline, timestamp, salt, witness, WITNESS_TYPE_STRING);
 
-            permit3.permitWitnessTransferFrom(
-                owner, salt, deadline, timestamp, chainPermits, witness, WITNESS_TYPE_STRING, signature
+            permit3.permitWitness(
+                owner, salt, deadline, timestamp, chainPermits.permits, witness, WITNESS_TYPE_STRING, signature
             );
         }
 
@@ -236,8 +243,8 @@ contract Permit3WitnessTest is Test {
             bytes memory signature =
                 _signWitnessPermit(chainPermits, deadline, timestamp, salt, witness, WITNESS_TYPE_STRING);
 
-            permit3.permitWitnessTransferFrom(
-                owner, salt, deadline, timestamp, chainPermits, witness, WITNESS_TYPE_STRING, signature
+            permit3.permitWitness(
+                owner, salt, deadline, timestamp, chainPermits.permits, witness, WITNESS_TYPE_STRING, signature
             );
         }
 
@@ -246,7 +253,7 @@ contract Permit3WitnessTest is Test {
     }
 
     // Test cross-chain witness functionality with UnhingedProofs
-    function test_permitWitnessTransferFromCrossChain() public {
+    function test_permitWitnessCrossChain() public {
         // Set specific values to ensure consistent calculation
         vm.warp(1000); // Set specific timestamp for reproducible results
 
@@ -260,9 +267,7 @@ contract Permit3WitnessTest is Test {
             _signWitnessUnhingedPermit(proof, deadline, timestamp, SALT, WITNESS, WITNESS_TYPE_STRING);
 
         // Execute cross-chain permit
-        permit3.permitWitnessTransferFrom(
-            owner, SALT, deadline, timestamp, proof, WITNESS, WITNESS_TYPE_STRING, signature
-        );
+        permit3.permitWitness(owner, SALT, deadline, timestamp, proof, WITNESS, WITNESS_TYPE_STRING, signature);
 
         // Verify transfer happened
         assertEq(token.balanceOf(recipient), AMOUNT);
@@ -282,7 +287,7 @@ contract Permit3WitnessTest is Test {
             amountDelta: AMOUNT
         });
 
-        return IPermit3.ChainPermits({ chainId: block.chainid, permits: permits });
+        return IPermit3.ChainPermits({ chainId: uint64(block.chainid), permits: permits });
     }
 
     function _createWrongChainTransferPermit() internal pure returns (IPermit3.ChainPermits memory) {
@@ -309,7 +314,7 @@ contract Permit3WitnessTest is Test {
             amountDelta: AMOUNT
         });
 
-        return IPermit3.ChainPermits({ chainId: block.chainid, permits: permits });
+        return IPermit3.ChainPermits({ chainId: uint64(block.chainid), permits: permits });
     }
 
     function _createUnhingedProof() internal view returns (IPermit3.UnhingedPermitProof memory) {
@@ -479,17 +484,17 @@ contract Permit3WitnessTest is Test {
     }
 
     function _hashChainPermits(
-        IPermit3.ChainPermits memory permits
+        IPermit3.ChainPermits memory chainPermits
     ) internal pure returns (bytes32) {
-        bytes32[] memory permitHashes = new bytes32[](permits.permits.length);
+        bytes32[] memory permitHashes = new bytes32[](chainPermits.permits.length);
 
-        for (uint256 i = 0; i < permits.permits.length; i++) {
+        for (uint256 i = 0; i < chainPermits.permits.length; i++) {
             permitHashes[i] = keccak256(
                 abi.encode(
-                    permits.permits[i].modeOrExpiration,
-                    permits.permits[i].token,
-                    permits.permits[i].account,
-                    permits.permits[i].amountDelta
+                    chainPermits.permits[i].modeOrExpiration,
+                    chainPermits.permits[i].token,
+                    chainPermits.permits[i].account,
+                    chainPermits.permits[i].amountDelta
                 )
             );
         }
@@ -499,7 +504,7 @@ contract Permit3WitnessTest is Test {
                 keccak256(
                     "ChainPermits(uint64 chainId,AllowanceOrTransfer[] permits)AllowanceOrTransfer(uint48 transferOrExpiration,address token,address spender,uint160 amountDelta)"
                 ),
-                permits.chainId,
+                chainPermits.chainId,
                 keccak256(abi.encodePacked(permitHashes))
             )
         );

--- a/test/Permit3Witness.t.sol
+++ b/test/Permit3Witness.t.sol
@@ -126,7 +126,8 @@ contract Permit3WitnessTest is Test {
         bytes memory signature =
             _signWitnessPermit(chainPermits, deadline, timestamp, SALT, WITNESS, WITNESS_TYPE_STRING);
 
-        vm.expectRevert(abi.encodeWithSelector(INonceManager.WrongChainId.selector, uint64(block.chainid), 1));
+        // Should revert with InvalidSignature (signature was created for wrong chain ID)
+        vm.expectRevert(abi.encodeWithSelector(INonceManager.InvalidSignature.selector));
         permit3.permitWitness(
             owner, SALT, deadline, timestamp, chainPermits.permits, WITNESS, WITNESS_TYPE_STRING, signature
         );
@@ -502,7 +503,7 @@ contract Permit3WitnessTest is Test {
         return keccak256(
             abi.encode(
                 keccak256(
-                    "ChainPermits(uint64 chainId,AllowanceOrTransfer[] permits)AllowanceOrTransfer(uint48 transferOrExpiration,address token,address spender,uint160 amountDelta)"
+                    "ChainPermits(uint64 chainId,AllowanceOrTransfer[] permits)AllowanceOrTransfer(uint48 modeOrExpiration,address token,address account,uint160 amountDelta)"
                 ),
                 chainPermits.chainId,
                 keccak256(abi.encodePacked(permitHashes))

--- a/test/TestUtils.t.sol
+++ b/test/TestUtils.t.sol
@@ -95,7 +95,8 @@ contract TestUtilsTest is Test {
             amountDelta: 500
         });
 
-        IPermit3.ChainPermits memory chainPermits = IPermit3.ChainPermits({ chainId: block.chainid, permits: permits });
+        IPermit3.ChainPermits memory chainPermits =
+            IPermit3.ChainPermits({ chainId: uint64(block.chainid), permits: permits });
 
         // Hash using utility
         bytes32 hash = Permit3TestUtils.hashChainPermits(permit3, chainPermits);
@@ -120,7 +121,7 @@ contract TestUtilsTest is Test {
 
     function test_hashEmptyChainPermits() public view {
         // Test hashEmptyChainPermits function
-        uint256 chainId = block.chainid;
+        uint64 chainId = uint64(block.chainid);
         bytes32 emptyHash = Permit3TestUtils.hashEmptyChainPermits(permit3, chainId);
 
         // Create empty permits manually
@@ -142,7 +143,7 @@ contract TestUtilsTest is Test {
             Permit3TestUtils.createTransferPermit(testToken, testRecipient, testAmount);
 
         // Verify the permit structure
-        assertEq(transferPermit.chainId, block.chainid);
+        assertEq(transferPermit.chainId, uint64(block.chainid));
         assertEq(transferPermit.permits.length, 1);
         assertEq(transferPermit.permits[0].modeOrExpiration, 0); // Transfer mode
         assertEq(transferPermit.permits[0].token, testToken);

--- a/test/utils/TestBase.sol
+++ b/test/utils/TestBase.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import { Test } from "forge-std/Test.sol";
+
 import "../../src/Permit3.sol";
 import "../../src/interfaces/IPermit3.sol";
 import "../../src/lib/UnhingedMerkleTree.sol";
 import "./TestUtils.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import { Test } from "forge-std/Test.sol";
 
 /**
  * @title TestBase

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -75,11 +75,11 @@ library Permit3TestUtils {
      * @param chainId The chain ID
      * @return The hash of the chain permits with empty permits array
      */
-    function hashEmptyChainPermits(Permit3 permit3, uint256 chainId) internal pure returns (bytes32) {
+    function hashEmptyChainPermits(Permit3 permit3, uint64 chainId) internal pure returns (bytes32) {
         IPermit3.AllowanceOrTransfer[] memory emptyPermits = new IPermit3.AllowanceOrTransfer[](0);
-        IPermit3.ChainPermits memory permits = IPermit3.ChainPermits({ chainId: chainId, permits: emptyPermits });
+        IPermit3.ChainPermits memory chainPermits = IPermit3.ChainPermits({ chainId: chainId, permits: emptyPermits });
 
-        return hashChainPermits(permit3, permits);
+        return hashChainPermits(permit3, chainPermits);
     }
 
     /**
@@ -102,7 +102,7 @@ library Permit3TestUtils {
             amountDelta: amount
         });
 
-        return IPermit3.ChainPermits({ chainId: block.chainid, permits: permits });
+        return IPermit3.ChainPermits({ chainId: uint64(block.chainid), permits: permits });
     }
 
     /**


### PR DESCRIPTION
Major API refactoring to streamline permit operations:

- Rename permitWitnessTransferFrom to permitWitness for consistency
- Remove ChainPermits wrapper, use AllowanceOrTransfer[] directly
- Optimize type sizes: uint256→uint48 for deadline, uint256→uint64 for chainId
- Add empty array validation to prevent gas waste
- Update all documentation, examples, and type definitions
- Fix character encoding issues in code examples
- Maintain backward compatibility with Permit2 interfaces

This refactoring reduces gas costs, simplifies integration patterns, and provides clearer semantics for permit operations while preserving all existing functionality.