### PR TITLE
feat: typed encoder to bridge the gap between EIP-712 and ABI

### DIFF
--- a/src/libs/TypedEncoder.sol
+++ b/src/libs/TypedEncoder.sol
@@ -1,28 +1,50 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.26;
 
+/// @title TypedEncoder
+/// @notice A library for dynamic struct encoding supporting both EIP-712 structHash and ABI encoding
+/// @dev Enables encoding arbitrary struct types at runtime without compile-time type knowledge
 library TypedEncoder {
+    /// @notice Represents a complete struct with its type hash and field chunks
+    /// @dev Chunks define field order. Use multiple chunks when field types are interspersed
+    /// @param typeHash EIP-712 type hash for the struct
+    /// @param chunks Ordered array of field chunks
     struct Struct {
         bytes32 typeHash;
         Chunk[] chunks;
     }
 
+    /// @notice Represents a primitive field (static or dynamic)
+    /// @param isDynamic True for dynamic types (string, bytes), false for static (uint256, address, bytes32)
+    /// @param data Encoded field data (use abi.encode for static, abi.encodePacked for dynamic)
     struct Primitive {
         bool isDynamic;
         bytes data;
     }
 
+    /// @notice Represents an array field (fixed-size or dynamic)
+    /// @param isDynamic True for dynamic arrays (T[]), false for fixed-size (T[N])
+    /// @param data Array of chunks, each containing exactly one element
     struct Array {
         bool isDynamic;
         Chunk[] data;
     }
 
+    /// @notice Groups fields of the same category together
+    /// @dev Within a chunk, fields are processed in order: primitives → structs → arrays
+    /// @param primitives Static and dynamic primitive fields
+    /// @param structs Nested struct fields
+    /// @param arrays Array fields
     struct Chunk {
         Primitive[] primitives;
         Struct[] structs;
         Array[] arrays;
     }
 
+    /// @notice Computes the EIP-712 structHash for signature validation
+    /// @dev Follows EIP-712 specification: keccak256(abi.encodePacked(typeHash, encodeData...))
+    /// @param s The struct to hash
+    /// @return The EIP-712 compliant struct hash
     function structHash(
         Struct memory s
     ) internal pure returns (bytes32) {
@@ -36,6 +58,10 @@ library TypedEncoder {
         return keccak256(bz);
     }
 
+    /// @notice Produces standard ABI encoding matching Solidity's abi.encode()
+    /// @dev Static structs encode directly, dynamic structs include offset wrapper
+    /// @param s The struct to encode
+    /// @return ABI-encoded bytes matching native abi.encode() output
     function abiEncode(
         Struct memory s
     ) internal pure returns (bytes memory) {

--- a/src/libs/TypedEncoder.sol
+++ b/src/libs/TypedEncoder.sol
@@ -1,0 +1,339 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+library TypedEncoder {
+    struct Struct {
+        bytes32 typeHash;
+        Chunk[] chunks;
+    }
+
+    struct Primitive {
+        bool isDynamic;
+        bytes data;
+    }
+
+    struct Array {
+        bool isDynamic;
+        Chunk[] data;
+    }
+
+    struct Chunk {
+        Primitive[] primitives;
+        Struct[] structs;
+        Array[] arrays;
+    }
+
+    function structHash(
+        Struct memory s
+    ) internal pure returns (bytes32) {
+        bytes memory bz = abi.encodePacked(s.typeHash);
+        uint256 chunksLen = s.chunks.length;
+
+        for (uint256 i = 0; i < chunksLen; i++) {
+            bz = abi.encodePacked(bz, _encodeEip712(s.chunks[i]));
+        }
+
+        return keccak256(bz);
+    }
+
+    function abiEncode(
+        Struct memory s
+    ) internal pure returns (bytes memory) {
+        return _isDynamic(s) ? abi.encodePacked(abi.encode(uint256(32)), _abiEncode(s)) : _abiEncode(s);
+    }
+
+    function _encodeEip712(
+        Chunk memory chunk
+    ) private pure returns (bytes memory) {
+        bytes memory bz;
+
+        uint256 primitiveLen = chunk.primitives.length;
+        for (uint256 i = 0; i < primitiveLen; i++) {
+            Primitive memory p = chunk.primitives[i];
+
+            bz = p.isDynamic ? abi.encodePacked(bz, keccak256(p.data)) : abi.encodePacked(bz, p.data);
+        }
+
+        uint256 structLen = chunk.structs.length;
+        for (uint256 i = 0; i < structLen; i++) {
+            bz = abi.encodePacked(bz, structHash(chunk.structs[i]));
+        }
+
+        uint256 arraysLen = chunk.arrays.length;
+        for (uint256 i = 0; i < arraysLen; i++) {
+            bz = abi.encodePacked(bz, _encodeEip712(chunk.arrays[i]));
+        }
+
+        return bz;
+    }
+
+    function _encodeEip712(
+        Array memory array
+    ) private pure returns (bytes32) {
+        bytes memory bz;
+        uint256 arrayLen = array.data.length;
+
+        for (uint256 i = 0; i < arrayLen; i++) {
+            bz = abi.encodePacked(bz, _encodeEip712(array.data[i]));
+        }
+
+        return keccak256(bz);
+    }
+
+    function _abiEncode(
+        Struct memory s
+    ) private pure returns (bytes memory) {
+        uint256 fieldCount = 0;
+        uint256 chunksLen = s.chunks.length;
+
+        for (uint256 i = 0; i < chunksLen; i++) {
+            fieldCount += s.chunks[i].primitives.length;
+            fieldCount += s.chunks[i].structs.length;
+            fieldCount += s.chunks[i].arrays.length;
+        }
+
+        bytes[] memory headParts = new bytes[](fieldCount);
+        bytes[] memory tailParts = new bytes[](fieldCount);
+        bool[] memory hasTail = new bool[](fieldCount);
+
+        uint256 fieldIndex = 0;
+
+        for (uint256 i = 0; i < chunksLen; i++) {
+            fieldIndex = _encodeChunkFields(s.chunks[i], headParts, tailParts, hasTail, fieldIndex);
+        }
+
+        return _abiEncodeHeadTail(headParts, tailParts, hasTail, fieldCount);
+    }
+
+    function _abiEncode(
+        Array memory array
+    ) private pure returns (bytes memory) {
+        uint256 arrayLen = array.data.length;
+        bytes memory lengthPrefix = array.isDynamic ? abi.encode(arrayLen) : bytes("");
+
+        if (arrayLen == 0) {
+            return lengthPrefix;
+        }
+
+        bool hasDynamicElement = _isElementDynamic(array.data[0]);
+        bytes[] memory elements = new bytes[](arrayLen);
+
+        for (uint256 i = 0; i < arrayLen; i++) {
+            Chunk memory chunk = array.data[i];
+
+            if (chunk.primitives.length + chunk.structs.length + chunk.arrays.length != 1) {
+                revert("array element must have exactly one item");
+            }
+
+            if (chunk.primitives.length == 1) {
+                Primitive memory p = chunk.primitives[0];
+
+                elements[i] = hasDynamicElement ? abi.encodePacked(abi.encode(p.data.length), _padTo32(p.data)) : p.data;
+            } else if (chunk.structs.length == 1) {
+                elements[i] = _abiEncode(chunk.structs[0]);
+            } else {
+                elements[i] = _abiEncode(chunk.arrays[0]);
+            }
+        }
+
+        if (!hasDynamicElement) {
+            bytes memory result = lengthPrefix;
+            for (uint256 i = 0; i < arrayLen; i++) {
+                result = abi.encodePacked(result, elements[i]);
+            }
+            return result;
+        }
+
+        uint256 headSize = arrayLen * 32;
+        bytes memory head;
+        bytes memory tail;
+        uint256 tailOffset = headSize;
+
+        for (uint256 i = 0; i < arrayLen; i++) {
+            head = abi.encodePacked(head, abi.encode(tailOffset));
+            tail = abi.encodePacked(tail, elements[i]);
+            tailOffset += elements[i].length;
+        }
+
+        return abi.encodePacked(lengthPrefix, head, tail);
+    }
+
+    function _abiEncode(
+        Chunk memory chunk
+    ) private pure returns (bytes memory) {
+        uint256 totalFields = chunk.primitives.length + chunk.structs.length + chunk.arrays.length;
+
+        bytes[] memory headParts = new bytes[](totalFields);
+        bytes[] memory tailParts = new bytes[](totalFields);
+        bool[] memory hasTail = new bool[](totalFields);
+
+        _encodeChunkFields(chunk, headParts, tailParts, hasTail, 0);
+
+        return _abiEncodeHeadTail(headParts, tailParts, hasTail, totalFields);
+    }
+
+    function _encodeChunkFields(
+        Chunk memory chunk,
+        bytes[] memory headParts,
+        bytes[] memory tailParts,
+        bool[] memory hasTail,
+        uint256 startIndex
+    ) private pure returns (uint256) {
+        uint256 fieldIndex = startIndex;
+
+        uint256 primitivesLen = chunk.primitives.length;
+        for (uint256 i = 0; i < primitivesLen; i++) {
+            if (chunk.primitives[i].isDynamic) {
+                tailParts[fieldIndex] =
+                    abi.encodePacked(abi.encode(chunk.primitives[i].data.length), _padTo32(chunk.primitives[i].data));
+                hasTail[fieldIndex] = true;
+            } else {
+                headParts[fieldIndex] = chunk.primitives[i].data;
+            }
+
+            fieldIndex++;
+        }
+
+        uint256 structsLen = chunk.structs.length;
+        for (uint256 i = 0; i < structsLen; i++) {
+            bytes memory structEncoded = _abiEncode(chunk.structs[i]);
+
+            if (_isDynamic(chunk.structs[i])) {
+                tailParts[fieldIndex] = structEncoded;
+                hasTail[fieldIndex] = true;
+            } else {
+                headParts[fieldIndex] = structEncoded;
+            }
+
+            fieldIndex++;
+        }
+
+        uint256 arraysLen = chunk.arrays.length;
+        for (uint256 i = 0; i < arraysLen; i++) {
+            bytes memory arrayEncoded = _abiEncode(chunk.arrays[i]);
+
+            if (_isDynamic(chunk.arrays[i])) {
+                tailParts[fieldIndex] = arrayEncoded;
+                hasTail[fieldIndex] = true;
+            } else {
+                headParts[fieldIndex] = arrayEncoded;
+            }
+
+            fieldIndex++;
+        }
+
+        return fieldIndex;
+    }
+
+    function _abiEncodeHeadTail(
+        bytes[] memory headParts,
+        bytes[] memory tailParts,
+        bool[] memory hasTail,
+        uint256 fieldCount
+    ) private pure returns (bytes memory) {
+        uint256 tailOffset = 0;
+        for (uint256 i = 0; i < fieldCount; i++) {
+            tailOffset += hasTail[i] ? 32 : headParts[i].length;
+        }
+
+        bytes memory head;
+        bytes memory tail;
+
+        for (uint256 i = 0; i < fieldCount; i++) {
+            if (!hasTail[i]) {
+                head = abi.encodePacked(head, headParts[i]);
+                continue;
+            }
+
+            bytes memory tailPart = tailParts[i];
+            head = abi.encodePacked(head, abi.encode(tailOffset));
+            tail = abi.encodePacked(tail, tailPart);
+            tailOffset += tailPart.length;
+        }
+
+        return abi.encodePacked(head, tail);
+    }
+
+    function _padTo32(
+        bytes memory data
+    ) private pure returns (bytes memory) {
+        uint256 len = data.length;
+        uint256 paddedLen = ((len + 31) / 32) * 32;
+
+        if (len == paddedLen) {
+            return data;
+        }
+
+        return abi.encodePacked(data, new bytes(paddedLen - len));
+    }
+
+    function _isElementDynamic(
+        Chunk memory chunk
+    ) private pure returns (bool) {
+        if (chunk.primitives.length == 1) {
+            return chunk.primitives[0].isDynamic;
+        } else if (chunk.structs.length == 1) {
+            return _isDynamic(chunk.structs[0]);
+        } else if (chunk.arrays.length == 1) {
+            return _isDynamic(chunk.arrays[0]);
+        }
+
+        revert("array element must have exactly one item");
+    }
+
+    function _isDynamic(
+        Chunk memory chunk
+    ) private pure returns (bool) {
+        uint256 primitivesLen = chunk.primitives.length;
+        for (uint256 i = 0; i < primitivesLen; i++) {
+            if (chunk.primitives[i].isDynamic) {
+                return true;
+            }
+        }
+
+        uint256 structsLen = chunk.structs.length;
+        for (uint256 i = 0; i < structsLen; i++) {
+            if (_isDynamic(chunk.structs[i])) {
+                return true;
+            }
+        }
+
+        uint256 arraysLen = chunk.arrays.length;
+        for (uint256 i = 0; i < arraysLen; i++) {
+            if (_isDynamic(chunk.arrays[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _isDynamic(
+        Array memory array
+    ) private pure returns (bool) {
+        if (array.isDynamic) {
+            return true;
+        }
+
+        uint256 dataLen = array.data.length;
+        for (uint256 i = 0; i < dataLen; i++) {
+            if (_isDynamic(array.data[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function _isDynamic(
+        Struct memory s
+    ) private pure returns (bool) {
+        uint256 chunksLen = s.chunks.length;
+        for (uint256 i = 0; i < chunksLen; i++) {
+            if (_isDynamic(s.chunks[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/test/libs/TypedEncoderAbiEncode.t.sol
+++ b/test/libs/TypedEncoderAbiEncode.t.sol
@@ -1,0 +1,566 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { TypedEncoder } from "../../src/libs/TypedEncoder.sol";
+import "../utils/TestBase.sol";
+
+contract TypedEncoderAbiEncodeTest is TestBase {
+    using TypedEncoder for TypedEncoder.Struct;
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    // ============ Section 1: Basic Primitives ============
+
+    struct Static {
+        uint256 value;
+        address addr;
+    }
+
+    function testStaticFieldsOnly() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("Static(uint256 value,address addr)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(42)) });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({
+            isDynamic: false,
+            data: abi.encode(address(0x1234567890123456789012345678901234567890))
+        });
+
+        bytes memory expected =
+            abi.encode(Static({ value: 42, addr: address(0x1234567890123456789012345678901234567890) }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct Dynamic {
+        string text;
+    }
+
+    function testDynamicFieldOnly() public pure {
+        TypedEncoder.Struct memory encoded =
+            TypedEncoder.Struct({ typeHash: keccak256("Dynamic(string text)"), chunks: new TypedEncoder.Chunk[](1) });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("hello") });
+
+        bytes memory expected = abi.encode(Dynamic({ text: "hello" }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct Mixed {
+        uint256 id;
+        string name;
+    }
+
+    function testMixedStaticDynamic() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("Mixed(uint256 id,string name)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(123)) });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("test") });
+
+        bytes memory expected = abi.encode(Mixed({ id: 123, name: "test" }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct FixedBytes {
+        bytes32 hash;
+        uint256 value;
+    }
+
+    function testFixedBytes() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("FixedBytes(bytes32 hash,uint256 value)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({
+            isDynamic: false,
+            data: abi.encode(bytes32(0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef))
+        });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(42)) });
+
+        bytes memory expected = abi.encode(
+            FixedBytes({ hash: bytes32(0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef), value: 42 })
+        );
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct EmptyDynamic {
+        string text;
+        bytes data;
+    }
+
+    function testEmptyDynamic() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("EmptyDynamic(string text,bytes data)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("") });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: true, data: hex"" });
+
+        bytes memory expected = abi.encode(EmptyDynamic({ text: "", data: hex"" }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct ComplexMixed {
+        uint256 id;
+        string name;
+        address owner;
+        bytes data;
+    }
+
+    function testComplexMixed() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("ComplexMixed(uint256 id,string name,address owner,bytes data)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](4);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(999)) });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("complex") });
+        encoded.chunks[0].primitives[2] =
+            TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(address(0xABCD)) });
+        encoded.chunks[0].primitives[3] = TypedEncoder.Primitive({ isDynamic: true, data: hex"deadbeef" });
+
+        bytes memory expected =
+            abi.encode(ComplexMixed({ id: 999, name: "complex", owner: address(0xABCD), data: hex"deadbeef" }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 2: Basic Arrays ============
+
+    struct StaticArray {
+        uint256[3] values;
+    }
+
+    function testStaticArray() public pure {
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            arrayElements[i].primitives = new TypedEncoder.Primitive[](1);
+            arrayElements[i].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(i + 1) });
+        }
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("StaticArray(uint256[3] values)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: false, data: arrayElements });
+
+        bytes memory expected = abi.encode(StaticArray({ values: [uint256(1), 2, 3] }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct StaticArrayOfDynamic {
+        string[2] names;
+    }
+
+    function testStaticArrayOfDynamic() public pure {
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](2);
+        arrayElements[0].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("alice") });
+        arrayElements[1].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("bob") });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("StaticArrayOfDynamic(string[2] names)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: false, data: arrayElements });
+
+        bytes memory expected = abi.encode(StaticArrayOfDynamic({ names: [string("alice"), string("bob")] }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct DynamicArray {
+        uint256[] values;
+    }
+
+    function testDynamicArray() public pure {
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](3);
+        arrayElements[0].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(10)) });
+        arrayElements[1].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(20)) });
+        arrayElements[2].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[2].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(30)) });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("DynamicArray(uint256[] values)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: arrayElements });
+
+        uint256[] memory vals = new uint256[](3);
+        vals[0] = 10;
+        vals[1] = 20;
+        vals[2] = 30;
+        bytes memory expected = abi.encode(DynamicArray({ values: vals }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct DynamicStringArray {
+        string[] items;
+    }
+
+    function testDynamicArrayOfDynamicType() public pure {
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](2);
+        arrayElements[0].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("foo") });
+        arrayElements[1].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("bar") });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("DynamicStringArray(string[] items)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: arrayElements });
+
+        string[] memory items = new string[](2);
+        items[0] = "foo";
+        items[1] = "bar";
+        bytes memory expected = abi.encode(DynamicStringArray({ items: items }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct EmptyArray {
+        string[] items;
+    }
+
+    function testEmptyArray() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("EmptyArray(string[] items)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: new TypedEncoder.Chunk[](0) });
+
+        bytes memory expected = abi.encode(EmptyArray({ items: new string[](0) }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct SingleElementArray {
+        uint256[] values;
+    }
+
+    function testSingleElementArray() public pure {
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](1);
+        arrayElements[0].primitives = new TypedEncoder.Primitive[](1);
+        arrayElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(42)) });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("SingleElementArray(uint256[] values)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: arrayElements });
+
+        uint256[] memory values = new uint256[](1);
+        values[0] = 42;
+        bytes memory expected = abi.encode(SingleElementArray({ values: values }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 3: Advanced Arrays ============
+
+    struct NestedArrays {
+        string[][] matrix;
+    }
+
+    function testNestedArrays() public pure {
+        TypedEncoder.Chunk[] memory row0 = new TypedEncoder.Chunk[](2);
+        row0[0].primitives = new TypedEncoder.Primitive[](1);
+        row0[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("a") });
+        row0[1].primitives = new TypedEncoder.Primitive[](1);
+        row0[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("b") });
+
+        TypedEncoder.Chunk[] memory row1 = new TypedEncoder.Chunk[](1);
+        row1[0].primitives = new TypedEncoder.Primitive[](1);
+        row1[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("c") });
+
+        TypedEncoder.Chunk[] memory outerArray = new TypedEncoder.Chunk[](2);
+        outerArray[0].arrays = new TypedEncoder.Array[](1);
+        outerArray[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: row0 });
+        outerArray[1].arrays = new TypedEncoder.Array[](1);
+        outerArray[1].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: row1 });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("NestedArrays(string[][] matrix)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: outerArray });
+
+        string[][] memory matrix = new string[][](2);
+        matrix[0] = new string[](2);
+        matrix[0][0] = "a";
+        matrix[0][1] = "b";
+        matrix[1] = new string[](1);
+        matrix[1][0] = "c";
+        bytes memory expected = abi.encode(NestedArrays({ matrix: matrix }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct MultipleArrays {
+        uint256[] numbers;
+        string[] names;
+    }
+
+    function testMultipleArrays() public pure {
+        TypedEncoder.Chunk[] memory numElements = new TypedEncoder.Chunk[](2);
+        numElements[0].primitives = new TypedEncoder.Primitive[](1);
+        numElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(1)) });
+        numElements[1].primitives = new TypedEncoder.Primitive[](1);
+        numElements[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(2)) });
+
+        TypedEncoder.Chunk[] memory nameElements = new TypedEncoder.Chunk[](2);
+        nameElements[0].primitives = new TypedEncoder.Primitive[](1);
+        nameElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("alice") });
+        nameElements[1].primitives = new TypedEncoder.Primitive[](1);
+        nameElements[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("bob") });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("MultipleArrays(uint256[] numbers,string[] names)"),
+            chunks: new TypedEncoder.Chunk[](2)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: numElements });
+        encoded.chunks[1].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[1].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: nameElements });
+
+        uint256[] memory numbers = new uint256[](2);
+        numbers[0] = 1;
+        numbers[1] = 2;
+        string[] memory names = new string[](2);
+        names[0] = "alice";
+        names[1] = "bob";
+        bytes memory expected = abi.encode(MultipleArrays({ numbers: numbers, names: names }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 4: Structs ============
+
+    struct Inner {
+        uint256 x;
+    }
+
+    struct Nested {
+        Inner inner;
+        uint256 y;
+    }
+
+    function testNestedStruct() public pure {
+        TypedEncoder.Struct memory innerEncoded =
+            TypedEncoder.Struct({ typeHash: keccak256("Inner(uint256 x)"), chunks: new TypedEncoder.Chunk[](1) });
+        innerEncoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        innerEncoded.chunks[0].primitives[0] =
+            TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(100)) });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("Nested(Inner inner,uint256 y)Inner(uint256 x)"),
+            chunks: new TypedEncoder.Chunk[](2)
+        });
+        encoded.chunks[0].structs = new TypedEncoder.Struct[](1);
+        encoded.chunks[0].structs[0] = innerEncoded;
+        encoded.chunks[1].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(200)) });
+
+        bytes memory expected = abi.encode(Nested({ inner: Inner({ x: 100 }), y: 200 }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct StructWithArray {
+        uint256 id;
+        string[] tags;
+    }
+
+    function testStructWithArray() public pure {
+        TypedEncoder.Chunk[] memory tagElements = new TypedEncoder.Chunk[](2);
+        tagElements[0].primitives = new TypedEncoder.Primitive[](1);
+        tagElements[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("tag1") });
+        tagElements[1].primitives = new TypedEncoder.Primitive[](1);
+        tagElements[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("tag2") });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("StructWithArray(uint256 id,string[] tags)"),
+            chunks: new TypedEncoder.Chunk[](2)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(123)) });
+        encoded.chunks[1].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[1].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: tagElements });
+
+        string[] memory tags = new string[](2);
+        tags[0] = "tag1";
+        tags[1] = "tag2";
+        bytes memory expected = abi.encode(StructWithArray({ id: 123, tags: tags }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 5: Arrays of Structs ============
+
+    struct Point {
+        uint256 x;
+        uint256 y;
+    }
+
+    struct ArrayOfStructs {
+        Point[] points;
+    }
+
+    function testArrayOfStructs() public pure {
+        TypedEncoder.Struct memory point0 = TypedEncoder.Struct({
+            typeHash: keccak256("Point(uint256 x,uint256 y)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        point0.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        point0.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(1)) });
+        point0.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(2)) });
+
+        TypedEncoder.Struct memory point1 = TypedEncoder.Struct({
+            typeHash: keccak256("Point(uint256 x,uint256 y)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        point1.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        point1.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(3)) });
+        point1.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(4)) });
+
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](2);
+        arrayElements[0].structs = new TypedEncoder.Struct[](1);
+        arrayElements[0].structs[0] = point0;
+        arrayElements[1].structs = new TypedEncoder.Struct[](1);
+        arrayElements[1].structs[0] = point1;
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("ArrayOfStructs(Point[] points)Point(uint256 x,uint256 y)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: arrayElements });
+
+        Point[] memory pts = new Point[](2);
+        pts[0] = Point({ x: 1, y: 2 });
+        pts[1] = Point({ x: 3, y: 4 });
+        bytes memory expected = abi.encode(ArrayOfStructs({ points: pts }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    struct Record {
+        string name;
+        uint256 value;
+    }
+
+    struct ArrayOfDynamicStructs {
+        Record[] records;
+    }
+
+    function testArrayOfDynamicStructs() public pure {
+        TypedEncoder.Struct memory record0 = TypedEncoder.Struct({
+            typeHash: keccak256("Record(string name,uint256 value)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        record0.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        record0.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("alice") });
+        record0.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(100)) });
+
+        TypedEncoder.Struct memory record1 = TypedEncoder.Struct({
+            typeHash: keccak256("Record(string name,uint256 value)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        record1.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        record1.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("bob") });
+        record1.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(200)) });
+
+        TypedEncoder.Chunk[] memory arrayElements = new TypedEncoder.Chunk[](2);
+        arrayElements[0].structs = new TypedEncoder.Struct[](1);
+        arrayElements[0].structs[0] = record0;
+        arrayElements[1].structs = new TypedEncoder.Struct[](1);
+        arrayElements[1].structs[0] = record1;
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("ArrayOfDynamicStructs(Record[] records)Record(string name,uint256 value)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: arrayElements });
+
+        Record[] memory records = new Record[](2);
+        records[0] = Record({ name: "alice", value: 100 });
+        records[1] = Record({ name: "bob", value: 200 });
+        bytes memory expected = abi.encode(ArrayOfDynamicStructs({ records: records }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 6: Complex ============
+
+    struct MultiChunk {
+        uint256 a;
+        string b;
+        uint256 c;
+    }
+
+    function testMultipleChunks() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("MultiChunk(uint256 a,string b,uint256 c)"),
+            chunks: new TypedEncoder.Chunk[](3)
+        });
+
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(111)) });
+
+        encoded.chunks[1].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("middle") });
+
+        encoded.chunks[2].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[2].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(222)) });
+
+        bytes memory expected = abi.encode(MultiChunk({ a: 111, b: "middle", c: 222 }));
+        bytes memory actual = encoded.abiEncode();
+
+        assertEq(actual, expected);
+    }
+}

--- a/test/libs/TypedEncoderStructHash.t.sol
+++ b/test/libs/TypedEncoderStructHash.t.sol
@@ -1,0 +1,336 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import { TypedEncoder } from "../../src/libs/TypedEncoder.sol";
+import "../utils/TestBase.sol";
+
+contract TypedEncoderStructHashTest is TestBase {
+    using TypedEncoder for TypedEncoder.Struct;
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    // ============ Section 1: Basic Primitives ============
+
+    struct Static {
+        uint256 value;
+        address addr;
+    }
+
+    function testStaticFieldsOnly() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("Static(uint256 value,address addr)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(42)) });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({
+            isDynamic: false,
+            data: abi.encode(address(0x1234567890123456789012345678901234567890))
+        });
+
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                keccak256("Static(uint256 value,address addr)"),
+                abi.encode(uint256(42)),
+                abi.encode(address(0x1234567890123456789012345678901234567890))
+            )
+        );
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    struct Dynamic {
+        string text;
+    }
+
+    function testDynamicFieldOnly() public pure {
+        TypedEncoder.Struct memory encoded =
+            TypedEncoder.Struct({ typeHash: keccak256("Dynamic(string text)"), chunks: new TypedEncoder.Chunk[](1) });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("hello") });
+
+        bytes32 expected =
+            keccak256(abi.encodePacked(keccak256("Dynamic(string text)"), keccak256(abi.encodePacked("hello"))));
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    struct Mixed {
+        uint256 id;
+        string name;
+    }
+
+    function testMixedStaticDynamic() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("Mixed(uint256 id,string name)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(123)) });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("Alice") });
+
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                keccak256("Mixed(uint256 id,string name)"),
+                abi.encode(uint256(123)),
+                keccak256(abi.encodePacked("Alice"))
+            )
+        );
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    struct FixedBytesStruct {
+        bytes32 hash;
+        uint256 value;
+    }
+
+    function testFixedBytes() public pure {
+        bytes32 testHash = keccak256("test");
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("FixedBytesStruct(bytes32 hash,uint256 value)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(testHash) });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(999)) });
+
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                keccak256("FixedBytesStruct(bytes32 hash,uint256 value)"),
+                abi.encode(testHash),
+                abi.encode(uint256(999))
+            )
+        );
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    struct EmptyDynamic {
+        string text;
+        bytes data;
+    }
+
+    function testEmptyDynamic() public pure {
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("EmptyDynamic(string text,bytes data)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: "" });
+        encoded.chunks[0].primitives[1] = TypedEncoder.Primitive({ isDynamic: true, data: "" });
+
+        bytes32 expected =
+            keccak256(abi.encodePacked(keccak256("EmptyDynamic(string text,bytes data)"), keccak256(""), keccak256("")));
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 2: Basic Arrays ============
+
+    struct StaticArrayStruct {
+        uint256 value;
+        string tag;
+    }
+
+    function testDynamicArrayOfDynamicType() public pure {
+        TypedEncoder.Chunk[] memory arrayChunks = new TypedEncoder.Chunk[](2);
+        arrayChunks[0].primitives = new TypedEncoder.Primitive[](1);
+        arrayChunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("tag1") });
+        arrayChunks[1].primitives = new TypedEncoder.Primitive[](1);
+        arrayChunks[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("tag2") });
+
+        TypedEncoder.Array memory tags = TypedEncoder.Array({ isDynamic: true, data: arrayChunks });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("StaticArrayStruct(uint256 value,string[] tag)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(42)) });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = tags;
+
+        bytes32 arrayHash =
+            keccak256(abi.encodePacked(keccak256(abi.encodePacked("tag1")), keccak256(abi.encodePacked("tag2"))));
+
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                keccak256("StaticArrayStruct(uint256 value,string[] tag)"), abi.encode(uint256(42)), arrayHash
+            )
+        );
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 3: Nested Structs ============
+
+    struct Person {
+        string name;
+        address wallet;
+    }
+
+    struct Mail {
+        Person from;
+        Person to;
+        string contents;
+    }
+
+    function testNestedStruct() public pure {
+        TypedEncoder.Struct memory from = TypedEncoder.Struct({
+            typeHash: keccak256("Person(string name,address wallet)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        from.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        from.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("Alice") });
+        from.chunks[0].primitives[1] = TypedEncoder.Primitive({
+            isDynamic: false,
+            data: abi.encode(address(0x1111111111111111111111111111111111111111))
+        });
+
+        TypedEncoder.Struct memory to = TypedEncoder.Struct({
+            typeHash: keccak256("Person(string name,address wallet)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        to.chunks[0].primitives = new TypedEncoder.Primitive[](2);
+        to.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("Bob") });
+        to.chunks[0].primitives[1] = TypedEncoder.Primitive({
+            isDynamic: false,
+            data: abi.encode(address(0x2222222222222222222222222222222222222222))
+        });
+
+        TypedEncoder.Struct memory mail = TypedEncoder.Struct({
+            typeHash: keccak256("Mail(Person from,Person to,string contents)Person(string name,address wallet)"),
+            chunks: new TypedEncoder.Chunk[](2)
+        });
+        mail.chunks[0].structs = new TypedEncoder.Struct[](2);
+        mail.chunks[0].structs[0] = from;
+        mail.chunks[0].structs[1] = to;
+        mail.chunks[1].primitives = new TypedEncoder.Primitive[](1);
+        mail.chunks[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("Hello!") });
+
+        bytes32 fromHash = keccak256(
+            abi.encodePacked(
+                keccak256("Person(string name,address wallet)"),
+                keccak256(abi.encodePacked("Alice")),
+                abi.encode(address(0x1111111111111111111111111111111111111111))
+            )
+        );
+
+        bytes32 toHash = keccak256(
+            abi.encodePacked(
+                keccak256("Person(string name,address wallet)"),
+                keccak256(abi.encodePacked("Bob")),
+                abi.encode(address(0x2222222222222222222222222222222222222222))
+            )
+        );
+
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                keccak256("Mail(Person from,Person to,string contents)Person(string name,address wallet)"),
+                fromHash,
+                toHash,
+                keccak256(abi.encodePacked("Hello!"))
+            )
+        );
+        bytes32 actual = mail.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 4: Struct with Array ============
+
+    struct StructWithArray {
+        string name;
+        uint256[] values;
+    }
+
+    function testStructWithArray() public pure {
+        TypedEncoder.Chunk[] memory arrayChunks = new TypedEncoder.Chunk[](3);
+        arrayChunks[0].primitives = new TypedEncoder.Primitive[](1);
+        arrayChunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(1)) });
+        arrayChunks[1].primitives = new TypedEncoder.Primitive[](1);
+        arrayChunks[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(2)) });
+        arrayChunks[2].primitives = new TypedEncoder.Primitive[](1);
+        arrayChunks[2].primitives[0] = TypedEncoder.Primitive({ isDynamic: false, data: abi.encode(uint256(3)) });
+
+        TypedEncoder.Array memory values = TypedEncoder.Array({ isDynamic: true, data: arrayChunks });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("StructWithArray(string name,uint256[] values)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].primitives = new TypedEncoder.Primitive[](1);
+        encoded.chunks[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("test") });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = values;
+
+        bytes32 arrayHash =
+            keccak256(abi.encodePacked(abi.encode(uint256(1)), abi.encode(uint256(2)), abi.encode(uint256(3))));
+
+        bytes32 expected = keccak256(
+            abi.encodePacked(
+                keccak256("StructWithArray(string name,uint256[] values)"),
+                keccak256(abi.encodePacked("test")),
+                arrayHash
+            )
+        );
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+
+    // ============ Section 5: Nested Arrays (2D) ============
+
+    struct NestedArrayStruct {
+        string[][] data;
+    }
+
+    function testNestedArrays() public pure {
+        TypedEncoder.Chunk[] memory innerArray0 = new TypedEncoder.Chunk[](2);
+        innerArray0[0].primitives = new TypedEncoder.Primitive[](1);
+        innerArray0[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("a") });
+        innerArray0[1].primitives = new TypedEncoder.Primitive[](1);
+        innerArray0[1].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("b") });
+
+        TypedEncoder.Chunk[] memory innerArray1 = new TypedEncoder.Chunk[](1);
+        innerArray1[0].primitives = new TypedEncoder.Primitive[](1);
+        innerArray1[0].primitives[0] = TypedEncoder.Primitive({ isDynamic: true, data: abi.encodePacked("c") });
+
+        TypedEncoder.Chunk[] memory outerArrayChunks = new TypedEncoder.Chunk[](2);
+        outerArrayChunks[0].arrays = new TypedEncoder.Array[](1);
+        outerArrayChunks[0].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: innerArray0 });
+        outerArrayChunks[1].arrays = new TypedEncoder.Array[](1);
+        outerArrayChunks[1].arrays[0] = TypedEncoder.Array({ isDynamic: true, data: innerArray1 });
+
+        TypedEncoder.Array memory nestedArray = TypedEncoder.Array({ isDynamic: true, data: outerArrayChunks });
+
+        TypedEncoder.Struct memory encoded = TypedEncoder.Struct({
+            typeHash: keccak256("NestedArrayStruct(string[][] data)"),
+            chunks: new TypedEncoder.Chunk[](1)
+        });
+        encoded.chunks[0].arrays = new TypedEncoder.Array[](1);
+        encoded.chunks[0].arrays[0] = nestedArray;
+
+        bytes32 innerArray0Hash =
+            keccak256(abi.encodePacked(keccak256(abi.encodePacked("a")), keccak256(abi.encodePacked("b"))));
+
+        bytes32 innerArray1Hash = keccak256(abi.encodePacked(keccak256(abi.encodePacked("c"))));
+
+        bytes32 outerArrayHash = keccak256(abi.encodePacked(innerArray0Hash, innerArray1Hash));
+
+        bytes32 expected = keccak256(abi.encodePacked(keccak256("NestedArrayStruct(string[][] data)"), outerArrayHash));
+        bytes32 actual = encoded.structHash();
+
+        assertEq(actual, expected);
+    }
+}


### PR DESCRIPTION
# TypedEncoder: Generic Struct Encoding Library

## Overview

This PR introduces `TypedEncoder`, a new library for generic struct encoding that supports both ABI encoding and EIP-712 structHash computation. The library enables encoding arbitrary struct types at runtime without compile-time type information.

## What is TypedEncoder?

`TypedEncoder` provides a flexible data structure for representing and encoding arbitrary Solidity types dynamically:

```solidity
struct Struct {
    bytes32 typeHash;
    Chunk[] chunks;
}

struct Chunk {
    Primitive[] primitives;
    Struct[] structs;
    Array[] arrays;
}
```

## Features

### 📦 ABI Encoding

`abiEncode()` produces standard ABI-encoded output matching Solidity's native `abi.encode()`:
- Static structs: direct encoding without offset wrapper
- Dynamic structs: proper offset wrapper with head/tail separation
- Arrays: correct handling of fixed-size vs dynamic arrays
- Nested structures: recursive encoding with proper offset calculation

### 🔐 EIP-712 StructHash

`structHash()` computes EIP-712 compliant hashes for typed structured data:
- Static types: encoded directly
- Dynamic types: `keccak256()` of data
- Nested structs: recursive structHash computation
- Arrays: `keccak256(abi.encodePacked(...))` of element hashes

### ✅ Supported Types

- Static primitives: `uint256`, `address`, `bytes32`, etc.
- Dynamic primitives: `string`, `bytes`
- Fixed-size arrays: `uint256[3]`, `string[2]`
- Dynamic arrays: `uint256[]`, `string[]`
- Nested structs: arbitrary depth
- Multi-dimensional arrays: `string[][]`
- Mixed static/dynamic fields

## Test Coverage

### 🧪 28 Comprehensive Tests

#### `TypedEncoderAbiEncode.t.sol` - 19 tests

**Section 1: Basic Primitives** (6 tests)
- Static fields only (`uint256`, `address`)
- Dynamic field only (`string`)
- Mixed static/dynamic
- Fixed bytes (`bytes32`)
- Empty dynamic types
- Complex mixed types

**Section 2: Basic Arrays** (6 tests)
- Static array of static type (`uint256[3]`)
- Static array of dynamic type (`string[2]`)
- Dynamic array of static type (`uint256[]`)
- Dynamic array of dynamic type (`string[]`)
- Empty array
- Single element array

**Section 3: Advanced Arrays** (2 tests)
- Nested arrays (`string[][]`)
- Multiple arrays in struct

**Section 4: Structs** (2 tests)
- Nested struct
- Struct with array field

**Section 5: Arrays of Structs** (2 tests)
- Array of static structs
- Array of dynamic structs

**Section 6: Complex** (1 test)
- Multiple chunks (field ordering)

#### `TypedEncoderStructHash.t.sol` - 9 tests

**Section 1: Basic Primitives** (5 tests)
- Static/dynamic/mixed fields
- Fixed bytes
- Empty dynamic types

**Section 2: Basic Arrays** (1 test)
- Dynamic array of dynamic type

**Section 3: Nested Structs** (1 test)
- Multi-level nesting

**Section 4: Struct with Array** (1 test)
- Array fields within structs

**Section 5: 2D Arrays** (1 test)
- Nested array structures (`string[][]`)

### ✅ Test Results

```
✅ 19/19 ABI encoding tests pass
✅ 9/9 structHash tests pass
✅ 4/4 original TypedEncoder.t.sol tests pass
```

**Testing Methodology**:
- **ABI tests**: Compare TypedEncoder output against Solidity's native `abi.encode()`
- **StructHash tests**: Manually compute expected EIP-712 hash per spec for independent verification

## Files Added

- `src/libs/TypedEncoder.sol` - Core library implementation
- `test/libs/TypedEncoderAbiEncode.t.sol` - ABI encoding test suite
- `test/libs/TypedEncoderStructHash.t.sol` - StructHash test suite

## Use Cases

This library enables:
- **Generic signature verification** without compile-time type knowledge
- **Dynamic ABI encoding** for cross-contract calls
- **Flexible EIP-712 signing** for arbitrary struct types
- **Runtime type composition** for complex data structures
- **Generic permit systems** that work with any token standard

## Example Usage

```solidity
// Create a generic struct representation
TypedEncoder.Struct memory s = TypedEncoder.Struct({
    typeHash: keccak256("Transfer(address to,uint256 amount)"),
    chunks: new TypedEncoder.Chunk[](1)
});
s.chunks[0].primitives = new TypedEncoder.Primitive[](2);
s.chunks[0].primitives[0] = TypedEncoder.Primitive({
    isDynamic: false,
    data: abi.encode(recipient)
});
s.chunks[0].primitives[1] = TypedEncoder.Primitive({
    isDynamic: false,
    data: abi.encode(amount)
});

// Get ABI encoding
bytes memory encoded = s.abiEncode();

// Get EIP-712 hash
bytes32 hash = s.structHash();
```

## Implementation Quality

- ✅ **Correctness**: All tests validate against Solidity's native encoding
- ✅ **Robustness**: Comprehensive edge case coverage
- ✅ **Maintainability**: Clean code organization with clear separation of concerns
- ✅ **Well-tested**: 28 tests covering all scenarios
