### PR TITLE
docs: fix documentation formatting in IPermit3

### DIFF
--- a/src/interfaces/IPermit3.sol
+++ b/src/interfaces/IPermit3.sol
@@ -84,7 +84,7 @@ interface IPermit3 is IPermit, INonceManager {
      * @dev Used in EIP-712 signatures to provide transparency to users about what they're signing
      * @dev Can represent either leaf nodes (ChainPermits) or internal tree nodes (nested levels)
      * @dev Both arrays should be ordered by hash value as merkle tree construction requires
-     * @param levels Child tree nodes for internal nodes (ordered by hash value)
+     * @param nodes Child tree nodes for internal nodes (ordered by hash value)
      * @param permits Leaf nodes showing actual chain permits for user visibility (ordered by hash value)
      */
     struct PermitNode {
@@ -94,8 +94,8 @@ interface IPermit3 is IPermit, INonceManager {
 
     /**
      * @notice Input struct for tree-based permits containing tree structure data
-     * @param proofStructure Compact tree encoding
      * @param currentChainPermits Permit operations for the current chain
+     * @param proofStructure Compact tree encoding
      * @param proof Array of hashes for proof reconstruction
      */
     struct PermitTree {

--- a/test/Permit3Edge.t.sol
+++ b/test/Permit3Edge.t.sol
@@ -734,7 +734,7 @@ contract Permit3EdgeTest is Test {
         (amount, expiration, ts) = permit3.allowance(owner, address(token), spender);
         assertEq(amount, 0); // Amount remains unchanged by unlock operation
         assertEq(expiration, 0); // No expiration (unlocked)
-            // Note: timestamp should remain from lock operation since unlock only changes expiration
+        // Note: timestamp should remain from lock operation since unlock only changes expiration
         assertEq(ts, uint48(block.timestamp)); // Timestamp remains from lock operation
     }
 


### PR DESCRIPTION
Address PR feedback:
- Fix @param name from 'levels' to 'nodes' in PermitNode struct
- Reorder @param documentation to match struct field order in PermitTree

Changes:
- Corrected parameter documentation to match actual struct fields
- Improved documentation clarity and consistency