### PR TITLE
chore: remove dead _cachedChainId immutable in EIP712

### DIFF
--- a/src/lib/EIP712.sol
+++ b/src/lib/EIP712.sol
@@ -22,10 +22,10 @@ abstract contract EIP712 is IERC5267 {
     /// @dev Value of 1 enables signatures to work across all chains
     uint256 private constant CROSS_CHAIN_ID = 1;
 
-    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
-    // invalidate the cached domain separator if the chain id changes.
+    // Cache the domain separator as an immutable value, keyed only on `address(this)` so it can be invalidated if the
+    // contract address changes (e.g. via proxy). The chain id is intentionally NOT part of the cache key: the domain
+    // deliberately uses a constant chain id (CROSS_CHAIN_ID = 1) for cross-chain signature compatibility.
     bytes32 private immutable _cachedDomainSeparator;
-    uint256 private immutable _cachedChainId;
     address private immutable _cachedThis;
 
     bytes32 private immutable _hashedName;
@@ -54,7 +54,6 @@ abstract contract EIP712 is IERC5267 {
         _hashedName = keccak256(bytes(name));
         _hashedVersion = keccak256(bytes(version));
 
-        _cachedChainId = CROSS_CHAIN_ID;
         _cachedDomainSeparator = _buildDomainSeparator();
         _cachedThis = address(this);
     }


### PR DESCRIPTION
## Summary

Removes a dead immutable left over from forking OpenZeppelin's `EIP712`.

`src/lib/EIP712.sol` declared and wrote `_cachedChainId` in the constructor but **never read it**. In OZ's original, the cached domain separator is invalidated when either `address(this)` *or* `block.chainid` changes. This fork intentionally drops the chain-id half of that guard — the domain hardcodes `CROSS_CHAIN_ID = 1` so signatures are valid across all chains (cross-chain compatibility), and `_domainSeparatorV4()` only compares `address(this) == _cachedThis`. That left `_cachedChainId` orphaned.

## Changes
- Delete the `_cachedChainId` declaration and its constructor assignment.
- Reword the stale cache comment to reflect that the cache is keyed only on `address(this)` and that the constant chain id is deliberate for cross-chain compatibility.

`CROSS_CHAIN_ID` is untouched (still used to build the domain separator and in `eip712Domain()`).

## Verification
Behavior-preserving. `forge build` succeeds and `forge test` passes: **213 tests passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)