### PR TITLE
fix: gate signed ERC20 transfers with allowance lockdown (Cantina 3.1.2)

### DIFF
--- a/src/Permit3.sol
+++ b/src/Permit3.sol
@@ -338,6 +338,15 @@ contract Permit3 is IPermit3, MultiTokenPermit, NonceManager {
                 require(uint256(p.tokenKey) >> 160 == 0, InvalidTokenKeyForTransfer());
 
                 address token = address(uint160(uint256(p.tokenKey)));
+
+                // Gate signed transfers with the existing allowance lock mechanism (Cantina 3.1.2).
+                // The recipient (p.account) is the only counterparty committed in the signature, so an
+                // owner blocks a signed transfer to a given recipient via lockdown(token, recipient),
+                // which writes the same owner->tokenKey->recipient allowance slot read here.
+                if (allowances[owner][p.tokenKey][p.account].expiration == LOCKED_ALLOWANCE) {
+                    revert AllowanceLocked(owner, p.tokenKey, p.account);
+                }
+
                 _transferFrom(owner, p.account, p.amountDelta, token);
             } else {
                 _processAllowanceOperation(owner, timestamp, p);

--- a/test/Permit3.t.sol
+++ b/test/Permit3.t.sol
@@ -35,6 +35,47 @@ contract Permit3Test is TestBase {
         assertTrue(permit3.isNonceUsed(owner, SALT));
     }
 
+    function test_permitTransferFrom_blockedByLockdownOnRecipient() public {
+        // Cantina 3.1.2: an owner blocks a signed transfer to a given recipient by
+        // calling lockdown(token, recipient), which locks the owner->token->recipient slot.
+        IPermit3.ChainPermits memory chainPermits = _createBasicTransferPermit();
+
+        deal(address(token), recipient, 0);
+
+        uint48 deadline = uint48(block.timestamp + 1 hours);
+        uint48 timestamp = uint48(block.timestamp);
+        bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
+
+        // Owner locks down transfers to the recipient.
+        IPermit.TokenSpenderPair[] memory approvals = new IPermit.TokenSpenderPair[](1);
+        approvals[0] = IPermit.TokenSpenderPair({ token: address(token), spender: recipient });
+        vm.prank(owner);
+        permit3.lockdown(approvals);
+
+        // Submitting the signed transfer permit must now revert.
+        bytes32 tokenKey = bytes32(uint256(uint160(address(token))));
+        vm.expectRevert(abi.encodeWithSelector(IPermit.AllowanceLocked.selector, owner, tokenKey, recipient));
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
+
+        // Recipient balance unchanged.
+        assertEq(token.balanceOf(recipient), 0);
+    }
+
+    function test_permitTransferFrom_succeedsWithoutLockdown() public {
+        // Happy path with no lockdown still transfers successfully.
+        IPermit3.ChainPermits memory chainPermits = _createBasicTransferPermit();
+
+        deal(address(token), recipient, 0);
+
+        uint48 deadline = uint48(block.timestamp + 1 hours);
+        uint48 timestamp = uint48(block.timestamp);
+        bytes memory signature = _signPermit(chainPermits, deadline, timestamp, SALT);
+
+        permit3.permit(owner, SALT, deadline, timestamp, chainPermits.permits, signature);
+
+        assertEq(token.balanceOf(recipient), AMOUNT);
+    }
+
     function test_permitTransferFromExpired() public {
         // Create the permit
         IPermit3.ChainPermits memory chainPermits = _createBasicTransferPermit();


### PR DESCRIPTION
## Summary

Addresses **Cantina finding 3.1.2 (High)**. A signed `permit(...)` carrying a `TransferERC20` op (`modeOrExpiration == 0`) called `_transferFrom` directly in `_processChainPermits` with **no lock check**, so `lockdown()` could not stop it.

This change adds a lock gate to the signed transfer path by **reusing the existing `owner -> tokenKey -> spender` allowance lock mechanism** (product decision: reuse, not a new mapping). Before performing the signed transfer it reverts `AllowanceLocked` if the recipient-keyed allowance is locked.

```solidity
if (allowances[owner][p.tokenKey][p.account].expiration == LOCKED_ALLOWANCE) {
    revert AllowanceLocked(owner, p.tokenKey, p.account);
}
```

## Chosen key semantics

`lockdown(token, recipient)` blocks signed transfers to that recipient, where **recipient = `p.account`**.

For a signed transfer, the only counterparty committed in the signature is the recipient `p.account` — `msg.sender` is just an arbitrary relayer, unknown at lock time. So an owner blocks a signed transfer to a given recipient by calling `lockdown([{token, recipient}])`.

**Key derivation lines up.** `lockdown` writes to `bytes32(uint256(uint160(token)))` (`PermitBase.sol:159`). The transfer branch requires `uint256(p.tokenKey) >> 160 == 0` (`Permit3.sol:338`) and derives `token = address(uint160(uint256(p.tokenKey)))`, so for a valid transfer op `p.tokenKey == bytes32(uint256(uint160(token)))` exactly. The check reads `allowances[owner][p.tokenKey][p.account]` — the same slot `lockdown(token, recipient)` writes. Confirmed they match.

The signature still authorizes the transfer; this only **adds** a lock gate. The allowance is not consumed/decremented, and the happy path is unchanged when nothing is locked.

## Residual limitation (explicit)

This does **NOT** stop a leaked signature that sends to an arbitrary/unknown recipient, because the owner cannot know the recipient at lock time. The general kill-switch for a leaked signature remains `invalidateNonces(salt)`.

This change is **defense-in-depth / parity with the NFT `CollectionLocked` fix**, not a complete mitigation of the leaked-signature threat.

## Tests

Added regression tests in `test/Permit3.t.sol`:
- `test_permitTransferFrom_blockedByLockdownOnRecipient` — owner signs a transfer to `recipient`, calls `lockdown([{token, recipient}])`, the permit reverts `AllowanceLocked`, recipient balance unchanged.
- `test_permitTransferFrom_succeedsWithoutLockdown` — happy path still transfers successfully.

Full suite: `forge test` -> **215 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)